### PR TITLE
Link fontconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,5 +182,5 @@ target_link_libraries(
           obsidian_ajpoly
           obsidian_zdbsp
           obsidian_slump
-	  fontconfig
+          fontconfig
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,4 +182,5 @@ target_link_libraries(
           obsidian_ajpoly
           obsidian_zdbsp
           obsidian_slump
+	  fontconfig
 )


### PR DESCRIPTION
I encountered a linker error without this line in CMakeLists.txt.