### PR TITLE
add symlink utility target to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,19 @@ if(UNIX)
   target_link_libraries(obsidian PRIVATE X11::Xft)
 endif()
 
+# symlinks the obsidian and filename_formatter binaries
+if(UNIX)
+  add_custom_target(
+    symlink ALL
+    COMMAND
+      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_BINARY_DIR}/obsidian"
+      "${CMAKE_CURRENT_LIST_DIR}/obsidian" && ${CMAKE_COMMAND} -E
+      create_symlink
+      "${CMAKE_BINARY_DIR}/source_files/ff_src/filename_formatter"
+      "${CMAKE_CURRENT_LIST_DIR}/tools/filename_formatter"
+  )
+endif()
+
 target_link_libraries(
   obsidian
   PRIVATE zlibstatic


### PR DESCRIPTION
This also happens to fix a bug where if the filename_formatter isn't in the tools/ directory, you get some pretty output in the filenames it "generates". It fixes it by linking filename_formatter to be in tools/ on every build.