### PR TITLE
Mark FLTK/zlib as optional to have installed

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,12 +13,12 @@
 3. CMake Utilities:
    * package: `cmake` 
 
-4. FLTK 1.3 
+4. FLTK 1.3 (optional)
    * website: http://www.fltk.org/
    * package: `libfltk1.3-dev`
    * You may also need: `libxft-dev` `libxinerama-dev` `libjpeg-dev` `libpng-dev` `libfontconfig1-dev`
 
-5. zlib
+5. zlib (optional)
    * website: http://www.zlib.net/
    * package: `zlib1g-dev`
 
@@ -34,15 +34,12 @@
 Assuming all those dependencies are met, then the following steps
 will build the Obsidian binary. (The '>' is just the prompt)
 
-    > mkdir build
-    > cd build
-    > cmake ..
-    > make (-j# optional, with # being the number of cores you'd like to use)
-    > cd ..
+    > cmake -B build
+    > cmake --build build (-j# optional, with # being the number of cores you'd like to use)
     
 Then, obsidian can be launched with:
 
-    > ./obsidian --install .
+    > ./build/obsidian --install .
 
 ## Windows Cross-Compilation on Linux using MinGW
 
@@ -50,11 +47,8 @@ You will need the `mingw-w64` package as well (or whatever name your distro uses
 
 Similar to the above directions:
 
-    > mkdir build
-    > cd build
-    > cmake .. -DCMAKE_TOOLCHAIN_FILE=../Toolchain-mingw64.cmake (use Toolchain-mingw32.cmake for a 32-bit build)
-    > make (-j# optional, with # being the number of cores you'd like to use)
-    > cd ..
+    > cmake -B build -DCMAKE_TOOLCHAIN_FILE=../Toolchain-mingw64.cmake (use Toolchain-mingw32.cmake for a 32-bit build)
+    > cmake --build build (-j# optional, with # being the number of cores you'd like to use)
     > cp build/obsidian.exe .
     > cp build/source_files/ff_src/filename_formatter.exe ./tools
 


### PR DESCRIPTION
Also: the build instructions use modern, cleaner CMake flags that don't require any directory wrangling.