### PR TITLE
Build filename_formatter for Obsidian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,8 @@ if(UNIX)
   )
 endif()
 
+add_dependencies(obsidian filename_formatter)
+
 target_link_libraries(
   obsidian
   PRIVATE zlibstatic


### PR DESCRIPTION
This fixes a compile error when trying to copy filename_formatter on a fresh clone.