### PR TITLE
Linux: Use $XDG_CONFIG_HOME instead of $HOME/.config if it exists.

### DIFF
--- a/source_files/obsidian_main/main.cc
+++ b/source_files/obsidian_main/main.cc
@@ -299,11 +299,15 @@ void Determine_WorkingPath(const char *argv0) {
     home_dir = std::filesystem::current_path();
 
 #else
-    home_dir = std::getenv("HOME");
-    home_dir /= ".config/obsidian";
-
+    home_dir = std::getenv("XDG_CONFIG_HOME");
+    home_dir /= "obsidian";
     if (!home_dir.is_absolute()) {
-        Main::FatalError("Unable to find $HOME directory!\n");
+        home_dir = std::getenv("HOME");
+        home_dir /= ".config/obsidian";
+
+        if (!home_dir.is_absolute()) {
+            Main::FatalError("Unable to find $HOME directory!\n");
+        }
     }
 
     // try to create it (doesn't matter if it already exists)


### PR DESCRIPTION
This change helps with XDG standards compliance, and will also help for a potential Flatpak build of Obsidian. Flatpak stores configs in a subdirectory: `$HOME/.var/app/$APP_ID/` where XDG_CONFIG_HOME for the app is set to `$HOME/.var/app/$APP_ID/config`, and the sandbox does not ordinarily have access to the standard fallback of `$HOME/.config`. A hole can be poked--in fact, one is for GZDoom--but I figure it's better to do it right if we can.

I can think of two other changes that will be necessary for a Flatpak build; first, Obsidian will need to search `/app` for its installation files, as that's the standard prefix that is passed to apps built in Flatpak. That part's easy though. I already see where to do it and will send that PR along soon.

The second part is harder, but fortunately, not *strictly* necessary, and I am not sure we have any control over it. We need to use the xdg-desktop-portal for saving files so that we don't have to poke any huge holes into the sandbox, and so that the platform's native file chooser appears instead of the horrid GTK2 one that currently appears. That may be at the FLTK level, and not something that Obsidian itself can do. But FLTK 1.4, due in April, is looking like it will support Wayland, so that might include portal support.