### PR TITLE
Linux: Add /app to install dir search paths.

### DIFF
--- a/source_files/obsidian_main/main.cc
+++ b/source_files/obsidian_main/main.cc
@@ -361,6 +361,7 @@ void Determine_InstallDir(const char *argv0) {
         "/usr/local",
         "/usr",
         "/opt",
+        "/app",
     };
 
     for (const char *prefix : prefixes) {


### PR DESCRIPTION
A companion PR to #401, to ease the creation of a potential Flatpak build of Obsidian. As mentioned in that PR, the standard prefix passed to build tools for making Flatpak packages is `/app`, so search there as well.

The only thing left after this and #401 is xdg-desktop-portal integration, but these two PRs, if merged, would be enough to create a preliminary Flatpak build directly from the main branch. It would need a huge hole punched into the sandbox to access `$HOME`, but it should work.