### PR TITLE
Fix compilation due to std::array shenanigans

### DIFF
--- a/source_files/obsidian_main/main.cc
+++ b/source_files/obsidian_main/main.cc
@@ -18,6 +18,7 @@
 //
 //------------------------------------------------------------------------
 
+#include <array>
 #include "main.h"
 #include "fmt/core.h"
 #include "images.h"
@@ -398,7 +399,7 @@ void Determine_InstallDir(const char *argv0) {
 #ifdef WIN32
     install_dir = home_dir;
 #else
-    constexpr std::array prefixes = {
+    constexpr std::array<const char *, 4> prefixes = {
         "/usr/local",
         "/usr",
         "/opt",


### PR DESCRIPTION
Why did this break? I don't know.