### PR TITLE
Russian translation #4 pull request + adjustment offsets in the Themes menu.

### DIFF
--- a/language/ru.po
+++ b/language/ru.po
@@ -3649,7 +3649,7 @@ msgstr "Процент карт с улицами"
 
 #: modules/miscellaneous.lua:300
 msgid "Allows Oblige to create large street-like outdoor rooms."
-msgstr "Позволяет создавать обширные похожие на улицы комнаты."
+msgstr "Позволяет создавать обширные комнаты, похожие на улицы."
 
 #: modules/miscellaneous.lua:307
 msgid "Streets-Friendly Themes Only"
@@ -5938,15 +5938,15 @@ msgstr "Управление силой перепадов высот по вс�
 
 #: modules/ui_arch.lua:257
 msgid "Bottomless Vistas"
-msgstr "Виды на бездонные пропасти"
+msgstr "Виды ниже линии горизонта"
 
 #: modules/ui_arch.lua:260
 msgid "This feature allows for vistas that show more of the skybox below the horizon. This does not prevent skybox tiling."
-msgstr "Позволяет использовать виды на пространства, захватывающие часть скайбокса ниже горизонта. Функция не предотвращает его тайлинг."
+msgstr "Позволяет использовать виды на пространства, захватывающие часть скайбокса ниже горизонта — \"бездонные\" виды. Функция не предотвращает тайлинг текстуры неба."
 
 #: modules/ui_arch.lua:261
 msgid "Enable - Bottomless vistas can always show. Pick this choice when using 3D Skyboxes.\n\nSky-gen Smart - Bottomless vistas appear only on episodes with no mountain backdrop based on the Sky Generator.\n\nDisable - Old Oblige behavior - no bottomless vistas."
-msgstr ""
+msgstr "Включено: бездонные виды могут быть сгенерированы в любом случае. Зачастую применимо вместе с использованием 3D-скайбоксов.\n\nВ зависимости от неба: позволять генерировать подобные виды только если небо на уровне не имеет рельефа (например, гор или пещер).\n\nОтключено: не генерировать виды — использовать старое поведение Oblige."
 
 #: modules/ui_arch.lua:268
 msgid "ZDoom 3D Skybox"
@@ -5954,11 +5954,11 @@ msgstr "3D-скайбокс ZDoom"
 
 #: modules/ui_arch.lua:271
 msgid "Choose if 3D Skyboxes are rendered into levels and their style."
-msgstr ""
+msgstr "Генерировать ли 3D-скайбоксы. Если \"да\", то при каком условии они будут сменять друг друга."
 
 #: modules/ui_arch.lua:272
 msgid "This is highly recommended when Bottomless Vistas are enabled in combination with a ZDoom Family engine."
-msgstr ""
+msgstr "Для лучшего опыта использования рекомендуется включить опцию \"Виды ниже линии горизонта\"."
 
 #: modules/ui_mons.lua:25
 msgid "NONE"
@@ -6054,23 +6054,23 @@ msgstr "Нет"
 
 #: modules/ui_mons.lua:64
 msgid "DEFAULT"
-msgstr ""
+msgstr "ПО УМОЛЧАНИЮ"
 
 #: modules/ui_mons.lua:65
 msgid "Harder"
-msgstr ""
+msgstr "Сложнее"
 
 #: modules/ui_mons.lua:66
 msgid "Tougher"
-msgstr ""
+msgstr "Свирепее"
 
 #: modules/ui_mons.lua:67
 msgid "Fiercer"
-msgstr ""
+msgstr "Беспощаднее"
 
 #: modules/ui_mons.lua:68
 msgid "CRAZIER"
-msgstr ""
+msgstr "БЕЗУМИЕ"
 
 #: modules/ui_mons.lua:73
 msgid "Disabled"
@@ -6106,7 +6106,7 @@ msgstr "Изменяет количество монстров на уровне
 
 #: modules/ui_mons.lua:114
 msgid "For reference: Obsidian's default for normal is 1.0.\n\nMix It Up: Selects quantities specified between Upper and Lower Bound choices on a chosen by the user.\n\nProgressive: creates a curve of increasing monster population also based on the Fine Tune options below.\n\nIt does not matter if your Upper/Lower Bound selections are reversed. Progressive will pick the min VS max quantities selected.\n\nNone: No monsters. Why would you choose this option? \nTrivial: Very, very few monsters. Almost nothing to kill.\nSporadic: Very few monsters. Not many things to kill.\nMeager: Fewer monsters. Not challenging for the average player.\nEasy: Obsidian default quantity. Not too bad for casual players.\nModest: Slightly above default. Still pretty easy for most. \nBearable: Above average opposition. Getting warmer! \nRough: Slightly difficult. Equivalent to late 90s megawads. \nStrenuous: Baby steps into big boy difficulty. Lots to kill! \nFormidable/Harsh: 'Easy' level of difficult. Considerable opposition. \nPainful/Ferocious: Getting into slaughterwad territory. Difficult! \nUnforgiving/Punishing: Slaughterwad level difficulty. Skill needed. \nMurderous/Grueling: Extremely high monster count. \nUnrelenting/Arduous: An uphill battle. Expect to reload saves often! \nBarbaric/Savage: Up into the hardest slaughterwads out there. \nBrutal/Draconian: Legions of demons await you on this setting. \nMerciless: Hell will throw everything at you at this setting, you masochist."
-msgstr ""
+msgstr "О связанных опциях \"Количество монстров\", \"Верхний предел\" и \"Нижний предел\".\n\nВарианты для значение количества монстров (по умолчанию для OBSIDIAN — 1.0):\nСлучайно: для каждого уровня выбирает новое значение между нижним и верхним пределами.\nПостепенно: сложность нарастает от нижнего предела до верхнего. Притом их порядок не имеет значения — если верхний предел окажется меньше нижнего, они поменяются местами."
 
 #: modules/ui_mons.lua:120
 msgid "Upper Bound"
@@ -6178,7 +6178,7 @@ msgstr "Тихий старт"
 
 #: modules/ui_mons.lua:186
 msgid "Makes start rooms mostly safe - no enemies and all outlooking windows are removed. (windows are retained on Procedural Gotchas) Default Obsidian behavior is 'no'."
-msgstr ""
+msgstr "Делает стартовые комнаты в большинстве своём безопасными, убирая всех монстров и не позволяя в ней создавать окна. Однако на босс-аренах пока что окна всё равно будут генерироваться."
 
 #: modules/ui_mons.lua:190
 msgid "Monster Variety"
@@ -7738,7 +7738,7 @@ msgstr "Движок"
 
 #: source_files/obsidian_main/ui_game.cc:192
 msgid "Available Engines:\n\nZDoom Family: L/G/ZDoom, Zandronum, and similar engines that use ZDoom as a base.\n\nVanilla DOOM: Doom with its original engine limits. This option will use SLUMP as the map builder.\n\nLimit Removing: Any engine that raises the limits of the original game to prevent crashes.\n\nBOOM Compatible: Engines compatible with Boom that are able to use the entire suite of Boom types and features.\n\nPrBoom Compatible: Boom-compatible, but also capable of using extended nodes.\n\nEDGE-Classic: Boom compatible, plus additional specials and other advanced features.\n\nEternity: Software renderer only, but with advanced features such as UDMF. Support is currently experimental."
-msgstr "Доступные игровые движки.\n\nСемейство ZDoom: (G-/L-/Q-)ZDoom, Zandronum, ZDaemon и другие, основанные на ZDoom.\n\nОригинальный Doom: Doom как таковой, в том числе с его ограничениями движка. При выборе этой опции будет использоваться генератор карт SLUMP.\n\nLimit Removing: любой игровой движок, расширяющий лимиты оригинала для предотвращения вылетов.\n\nСовместивый с BOOM: движки, совместимые с Boom, и позволяющие использовать все его возможности и расширения.\n\nСовместивый с PrBoom: то же, что выше, но также с расширенным использованием Map Nodes.\n\nКлассический EDGE: совместимый с BOOM, но с добавлениением некоторых специфичных для EDGE возможностей.\n\nEternity [экспериментальный]: для Software-рендерера, но с некоторыми улучшениями вроже UDMF."
+msgstr "Доступные игровые движки.\n\nСемейство ZDoom: (G-/L-/Q-)ZDoom, Zandronum, ZDaemon и другие, основанные на ZDoom.\n\nОригинальный Doom: движок Doom как таковой, с учётом его ограничений. При выборе этой опции будет использоваться генератор карт SLUMP.\n\nLimit Removing: любой игровой движок, расширяющий лимиты оригинала для предотвращения вылетов.\n\nСовместивый с BOOM: движки, совместимые с Boom, и позволяющие использовать все его возможности и расширения.\n\nСовместивый с PrBoom: то же, что выше, но также с расширенным использованием Map Nodes.\n\nКлассический EDGE: совместимый с BOOM, но с добавлениением некоторых специфичных для EDGE возможностей.\n\nEternity [экспериментальный]: для Software-рендерера, но с некоторыми улучшениями вроде UDMF."
 
 #: source_files/obsidian_main/ui_game.cc:197
 msgid "Length"

--- a/language/ru.po
+++ b/language/ru.po
@@ -1,4 +1,4 @@
-# Russian Language Translation for Obsidian by hytalego and Morthimer McMare.
+# Russian Language Translation for Obsidian by hytalego, Morthimer McMare and ika707.
 # [McM]: due to hytalego's total inactivity (also after attempts to contact him), I'll take responsibility to change the translation leader.
 #   PREVIOUS TEXT: "If helping with Russian translation, please send content to hytalego in a separate file instead of attempting to merge against this one".
 # This file is put in the public domain.
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Obsidian Level Maker\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-05-09 23:41+1000\n"
-"PO-Revision-Date: 2022-07-11 20:14+0300\n"
+"PO-Revision-Date: 2022-07-28 13:06+0300\n"
 "Last-Translator:  Morthimer McMare\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
@@ -1145,7 +1145,7 @@ msgstr "Выводить строки ZDoom"
 
 #: modules/debugger.lua:162
 msgid "Displays the story generator and custom quit message strings added by the ZDoom Special Addons: Story Generator."
-msgstr "Сохраняет генератор историй и новые сообщения выхода, добавляемые аддоном \"ZDoom Special Addons: Story Generator\"."
+msgstr "Сохраняет информацию генератора историй и новые сообщения выхода, добавляемые аддоном \"ZDoom Special Addons: Story Generator\"."
 
 #: modules/debugger.lua:169
 msgid "Build Level"
@@ -1157,11 +1157,11 @@ msgstr "Позволяет оставить генерацию только од
 
 #: modules/debugger.lua:184
 msgid "Shape Rule Stats"
-msgstr "Сохр. правила словоформ"
+msgstr "Сохр. правила генерации форм"
 
 #: modules/debugger.lua:187
 msgid "Displays usage statistics for shape grammar rules."
-msgstr "Сохраняет статистику использования правил грамматики"
+msgstr "Сохраняет статистику использования правил образования геометрических форм."
 
 #: modules/debugger.lua:194
 msgid "Save Map Previews"
@@ -2565,7 +2565,7 @@ msgstr "Освещение мест под небом"
 
 #: modules/heretic/sky_generator.lua:813
 msgid "Overrides (and ignores) Dark Outdoors setting in Miscellaneous tab. If the sky generator creates night skies for an episode, episode's map outdoors is also dark but bright if day-ish."
-msgstr ""
+msgstr "Переопределяет и, как следствие, игнорирует настройку \"Тёмные пространства под небом\". Если генератор неба создал ночные виды, то всё пространство под ним будет затемнённым, и наоборот — для дневного времени суток локации под небом будут ярко освещёнными."
 
 #: modules/heretic/zdoom_specials.lua:26
 msgid "Yes"
@@ -3337,7 +3337,7 @@ msgstr "(Случайно)"
 
 #: modules/miscellaneous.lua:58
 msgid "Mostly Short"
-msgstr "Довольно низкие"
+msgstr "В основном низкие"
 
 #: modules/miscellaneous.lua:59
 msgid "Slightly Short"
@@ -3353,7 +3353,7 @@ msgstr "Высоковатые"
 
 #: modules/miscellaneous.lua:62
 msgid "Mostly Tall"
-msgstr "Довольно высокие"
+msgstr "В основном высокие"
 
 #: modules/miscellaneous.lua:63
 msgid "Mix It Up"
@@ -3521,7 +3521,7 @@ msgstr ""
 
 #: modules/miscellaneous.lua:136
 msgid "Small-ish"
-msgstr "Уклон в небольшие"
+msgstr "Чаще небольшие"
 
 #: modules/miscellaneous.lua:137
 msgid "Small"
@@ -3533,7 +3533,7 @@ msgstr ""
 
 #: modules/miscellaneous.lua:139
 msgid "Large-ish"
-msgstr "Уклон в крупные"
+msgstr "Чаще крупные"
 
 #: modules/miscellaneous.lua:140
 msgid "Normal"
@@ -3545,7 +3545,7 @@ msgstr "Традиционно"
 
 #: modules/miscellaneous.lua:142
 msgid "Very Conservative"
-msgstr "Консервативно"
+msgstr "Крайне консервативно"
 
 #: modules/miscellaneous.lua:143
 msgid "Random"
@@ -3553,7 +3553,7 @@ msgstr ""
 
 #: modules/miscellaneous.lua:148
 msgid "Less-ish"
-msgstr "Уклон в меньшую сторону"
+msgstr "Чаще меньше"
 
 #: modules/miscellaneous.lua:149
 msgid "Less"
@@ -3565,7 +3565,7 @@ msgstr ""
 
 #: modules/miscellaneous.lua:151
 msgid "More-ish"
-msgstr "Уклон в большую сторону"
+msgstr "Чаще больше"
 
 #: modules/miscellaneous.lua:152
 msgid "Normal"
@@ -3621,7 +3621,7 @@ msgstr "Шанс того, что каждый конкретный уровен
 
 #: modules/miscellaneous.lua:256
 msgid "Layout consistency attempts to cause levels to overprefer specific shape rules from the ruleset in order to create odd but more consistent combinations of pieces to build the general layout. The effect will be more prominent in certain combinations and levels than others."
-msgstr "Единообразие общего макета геометрии — попытка предпочитать определённый набор правил геометрических форм всем другим. Это приводит к созданию чуть более странного, но и более цельного по структуре уровня. Эффект будет заметен не во всех комбинациях и уровнях."
+msgstr "Единообразие общего макета геометрии — попытка предпочитать определённый набор правил геометрических форм всем другим. Это приводит к созданию чуть более странного, но и более цельного по структуре уровня. Эффект будет заметен не во всех комбинациях и картах."
 
 #: modules/miscellaneous.lua:264
 msgid "Linear Mode"
@@ -3665,11 +3665,15 @@ msgstr "Множитель размеров комнат"
 
 #: modules/miscellaneous.lua:320
 msgid "Alters the general size and ground coverage of rooms.\n\nVanilla: No room size multipliers.\n\nMix It Up: All multiplier ranges are randomly used with highest and lowest multipliers being rarest."
-msgstr "Изменяет общий размер комнат.\n\nКак в оригинале: без множителя.\n\nСлучайно: все диапазоны множителей используются случайным образом, притом вероятность выбора крайних значений резко снижается (по распределению Гаусса-Лапласа)."
+msgstr "Изменяет общий размер комнат.\n\nКак в оригинале: множитель равен единице, то есть изменения нет.\n\nСлучайно: все диапазоны множителей используются случайным образом, притом вероятность выбора крайних значений резко снижается (по распределению Гаусса-Лапласа)."
 
 #: modules/miscellaneous.lua:325
 msgid "Area Count Multiplier"
 msgstr "Множитель дробности комнат"
+
+#: modules/miscellaneous.lua:328
+msgid "Alters the amount of areas in a room. Influences the amount rooms are divided into different elevations or simply different ceilings if a level has no steepness.\n\nVanilla: No area quantity multipliers.\n\nMix It Up: All multiplier ranges are randomly used with highest and lowest multipliers being rarest."
+msgstr "Изменяет возможное количество различных подлокаций в каждой комнате. Влияет на количество разных по высоте зон. Если уровень не должен иметь перепадов высот полов (должен быть плоским) — то настройка будет влиять только на потолки.\n\nКак в оригинале: множитель равен единице, то есть изменения нет.\n\nСлучайно: все диапазоны множителей используются случайным образом, притом вероятность выбора крайних значений резко снижается (по распределению Гаусса-Лапласа)."
 
 #: modules/miscellaneous.lua:337
 msgid "Size Consistency"
@@ -3681,19 +3685,19 @@ msgstr "Насколько строгое ограничение наклады�
 
 #: modules/miscellaneous.lua:346
 msgid "Room Size Mix Fine Tune"
-msgstr "Тип смешения размеров комнат"
+msgstr "Уклон случайных размеров комнат"
 
 #: modules/miscellaneous.lua:349
 msgid "Alters the behavior of Mix It Up for Room Size Multiplier options.\n\nNormal: Mix it up uses a normal curve distribution. Traditional-sized rooms are common and smaller or larger sizes are slightly less so.\n\nSmall-ish: Only smaller room sizes, but biased towards normal sizes.\n\nSmall: Biased towards smaller room sizes with no larger room sizes.\n\nLarge: Biased towards large rooms sizes with no smaller room sizes..\n\nLarge-ish: Only larger room sizes, but biased towards normal sizes.\n\nConservative: Probability is biased more towards regular room sizes, making much smaller or much larger rooms significantly rarer.\n\nVery Conservative: Bias is even stronger towards regular and smaller rooms sizes, while larger rooms are very rare.\n\nRandom: No curve distribution - room sizes and room area counts are picked completely randomly."
-msgstr ""
+msgstr "Изменяет поведение варианта \"Случайно\" настройки \"Множитель размеров комнат\".\n\nНормально: обычное распределение Гаусса-Лапласа. Наиболее часто встречаются комнаты среднего размера, вероятность выбора крайних значений резко снижается.\n\nЧаще небольшие: в основном небольшие комнаты, но с уклоном в сторону нормальных размеров.\n\nМеньше: сильный уклон в сторону малых комнат, обширных за всю игру можно и не встретить.\n\nБольше: сильный уклон в сторону обширных комнат, малых, можно считать, нет.\n\nЧаще крупные: в основном обширные комнаты, но с уклоном в сторону нормальных размеров.\n\nТрадиционно: вероятность больше смещена в сторону обычных размеров, что значительно понижает шанс появления комнат, отличных от средних.\n\nКрайне консервативно: вероятность смещена в сторону обычных и меньших размеров комнат, обширные встречаются неимоверно редко.\n\nСлучайно: никакое распределение не учитывается, размеры комнат выбираются абсолютно случайным образом."
 
 #: modules/miscellaneous.lua:355
 msgid "Room Area Mix Fine Tune"
-msgstr "Тип смешения дробности комнат"
+msgstr "Уклон случайной дробности комнат"
 
 #: modules/miscellaneous.lua:358
 msgid "Alters the behavior of Mix It Up for Room Area Multiplier options.\n\nNormal: Mix it up uses a normal curve distribution.\n\nLess-ish: Only rooms with less floors and simple ceilings, but biased towards normal counts.\n\nLess: Biased towards rooms with less floors and simple ceilings.\n\nMore: Biased towards rooms with more floors and complex ceilings.\n\nMore-ish: Only rooms with more floors and complex ceilings, but biased towards normal counts.\n\nConservative: Biased towards normal area counts.\n\nVery Conservative: Further biased towards normal area counts.\n\nRandom: No curve distribution - room area counts are picked completely randomly."
-msgstr ""
+msgstr "Изменяет поведение варианта \"Случайно\" настройки \"Множитель дробности комнат\".\n\nНормально: обычное распределение Гаусса-Лапласа. Наиболее часто выбирается среднее значение количества зон, вероятность очень большого или очень малого количества резко снижается.\n\nЧаше меньше: в основном комнаты с небольшой дробностью, но с уклоном в сторону обычного количества зон.\n\nМеньше: сильный уклон в сторону малого разбиения, практически изотропные комнаты.\n\nБольше: комнаты разбиваются на зоны практически всегда.\n\nЧаще больше: в основном комнаты с сильным делением, но с уклоном в сторону нормального количества подлокаций.\n\nТрадиционно: вероятность смещена в сторону обычного количества зон.\n\nКрайне консервативно: вероятность сильно смещена в сторону обычного количества зон, иные виды разбиения встречаются крайне редко.\n\nСлучайно: никакое распределение не учитывается, количество подлокаций для комнат выбирается абсолютно случайным образом."
 
 #: modules/miscellaneous.lua:365
 msgid "Big Rooms"
@@ -3717,7 +3721,7 @@ msgstr "Высоты комнат"
 
 #: modules/miscellaneous.lua:376
 msgid "Determines if rooms should have a height limit or should exaggerate their height. Short means room areas strictly have at most 128 units of height, tall means rooms immediately have doubled heights. Normal is the default Oblige behavior."
-msgstr ""
+msgstr "Определяет, насколько высокими будут комнаты. Варианты \"Низкие\" будет ограничивать максимальную высоту комнат до 128 маппикселей, \"Высокие\" — удваивать высоты."
 
 #: modules/miscellaneous.lua:385
 msgid "Parks"
@@ -3745,7 +3749,7 @@ msgstr "Автоподгонка кол-ва деталей"
 
 #: modules/miscellaneous.lua:399
 msgid "Reduces or increases the probability of park decorations such as trees on park rooms."
-msgstr "Изменяет шанс появления декораций в парках, например, таких, как деревья."
+msgstr "Изменяет шанс появления декораций в парках, таких, например, как деревья."
 
 #: modules/miscellaneous.lua:407
 msgid "Windows"
@@ -3769,7 +3773,7 @@ msgstr "Проходимые (3D) перила"
 
 #: modules/miscellaneous.lua:422
 msgid "Sets the passability of railing junctions between full impassability or the 3D midtex flag. Occasional means 3D midtex is only used on railings between areas the player is supposed to circumvent. Always means the inclusion of cages and scenic rails, allowing flying monsters to potentially escape.\n\nNote: 3D midtex lines currently *block* projectiles as well."
-msgstr "Устанавливает перилам флаг \"3D-midtex\" (вместо полной непроходимости). Иногда это означает, что этот флаг используется только на перилах между обязательными для посещения областями. Заборы, выходящие во внеигровые зоны, а также клетки непроходимы всегда, что не позволяет летающим монстрам уйти с предназначенных им позиций.\n\nПримечание: 3D-линии в настоящее время также *блокируют* снаряды."
+msgstr "Устанавливает перилам флаг \"3D-midtex\" (вместо полной непроходимости). Иногда это означает, что указанный флаг будет использоваться только на перилах между обязательными для посещения областями. Заборы, выходящие во внеигровые зоны, а также клетки непроходимы всегда, что не позволяет летающим монстрам уйти с предназначенных им позиций.\n\nПримечание: 3D-линии в настоящее время также *блокируют* снаряды."
 
 #: modules/miscellaneous.lua:429
 msgid "Symmetry"
@@ -3797,11 +3801,11 @@ msgstr "Создание толстых неплоходимых заборов 
 
 #: modules/miscellaneous.lua:447
 msgid "Porches\\Gazebos"
-msgstr "Террасы и беседки"
+msgstr "Террасы/беседки"
 
 #: modules/miscellaneous.lua:449
 msgid "Occasional outdoor areas with a lowered indoor-ish ceiling."
-msgstr ""
+msgstr "Периодические локации под открытым небом с пониженным потолком (как в помещениях)."
 
 #: modules/miscellaneous.lua:454
 msgid "Pictures"
@@ -3881,7 +3885,7 @@ msgstr "Двери"
 
 #: modules/miscellaneous.lua:535
 msgid "Control the amount of doors."
-msgstr "Контролирует количество дверей."
+msgstr "Управляет общим количеством дверей."
 
 #: modules/miscellaneous.lua:538
 msgid "Keyed Doors"
@@ -3889,7 +3893,7 @@ msgstr "Двери, запертые на ключ"
 
 #: modules/miscellaneous.lua:539
 msgid "Control the amount of keyed doors."
-msgstr ""
+msgstr "Управляет количеством дверей, запертых на ключ."
 
 #: modules/miscellaneous.lua:542
 msgid "Triple-Keyed Doors"
@@ -3897,7 +3901,7 @@ msgstr "Двери, запертые на три ключа"
 
 #: modules/miscellaneous.lua:544
 msgid "Controls the chance to get three key door whenever three keys are present."
-msgstr ""
+msgstr "Управляет шансом появления дверей, запертых на все три ключа, если те есть на уровне."
 
 #: modules/miscellaneous.lua:548
 msgid "Switch Goals"
@@ -3945,7 +3949,7 @@ msgstr "Линейные старты"
 
 #: modules/miscellaneous.lua:592
 msgid "Stops start rooms from having more than one external room connection. Can help reduce being overwhelmed by attacks from multiple directions when multiple neighboring rooms connect into the start room. Default means no control, and levels can have linear starts at random based on shape grammars as per original Oblige 7.7 behavior."
-msgstr ""
+msgstr "Не позволяет создавать стартовые комнаты, имеющие более одного прохода в соседние локации, может помочь уменьшить количество атак с разных направлений. \"По умолчанию\" означает отсутствие подобных проверок, однако уровни всё равно могут случайно сгенерироваться с линейным началом — в соответствии с исходным поведением Oblige 7.7."
 
 #: modules/miscellaneous.lua:598
 msgid "Dead Ends"
@@ -3953,7 +3957,7 @@ msgstr "Тупики"
 
 #: modules/miscellaneous.lua:600
 msgid "Cleans up and removes areas with staircases that lead to nowhere.\nNONE means all dead ends are removed.\nHeaps means all dead ends are preserved (Oblige default)."
-msgstr ""
+msgstr "Уменьшает количество тупиков, а иакже лестниц, ведущих в никуда.\n\nНет: все тупики будут убраны.\n\nМножество: не уменьшать количество тупиков (обычное поведение Oblige)."
 
 #: modules/miscellaneous.lua:610
 msgid "Lighting"
@@ -4001,8 +4005,7 @@ msgstr "Имя для каждого врага"
 
 #: modules/modded_game_extras.lua:2245
 msgid "Renames tags of monsters with generated names. Humans recieve human names, demons recieve exotic names.\nBest used with TargetSpy or other healthbar mods to see the name.\nUses class inheritance and string comparisons to determine monster species (human or demon). Use compatibility options only when necessary, preferably use Universal option instead."
-msgstr "Переопределение тэгов монстров со сгенерированными именами. Люди получают человеческие имена, демоны — экзотические.\nЛучше всего использовать с TargetSpy или иной модификацией, отображающей полоску здоровья оппонента.\nИспользует как проверку наследования от определённых классов, так и построковое сравнение для различия людей и демонов. Используйте параметр совместимости только при необходимости; универсальный параметр практически всегда предпочтительнее."
-
+msgstr "Переопределение тэгов монстров со сгенерированными именами. Люди получают человеческие имена, демоны — экзотические.\nЛучше всего использовать с TargetSpy или иной модификацией, отображающей полоску здоровья оппонента. Использует как проверку наследования от определённых классов, так и построковое сравнение для определения того, кто является человеком, кто — демоном.\n\nВыбирайте параметр совместимости только при необходимости; универсальный параметр практически всегда предпочтительнее [Прим. перев.: по-видимому, наследованная от предыдущих версий заметка, когда в этой настройке было больше вариантов]."
 
 #: modules/modded_game_extras.lua:2252
 msgid "QC:DE Lootboxes"
@@ -4022,7 +4025,7 @@ msgstr "Добавляет полевых дронов Death Foretold в таб�
 
 #: modules/modded_game_extras.lua:2272
 msgid "Trailblazer Upgrades"
-msgstr "Улучшения Trailblazer"
+msgstr "Улучшения из Trailblazer"
 
 #: modules/modded_game_extras.lua:2275
 msgid "Adds Trailblazer's upgrade blueprints as separate pickups that can be found in the map."
@@ -4474,19 +4477,19 @@ msgstr "Все"
 
 #: modules/procedural_gotcha.lua:53
 msgid "Procedural Gotchas"
-msgstr "Процедурные спец. уровни"
+msgstr "Процедурные босс-арены"
 
 #: modules/procedural_gotcha.lua:65
 msgid "This module allows you to fine tune the Procedural Gotcha experience if you have Procedural Gotchas enabled. Does not affect prebuilts. It is recommended to pick higher scales on one of the two options, but not both at once for a balanced challenge."
-msgstr ""
+msgstr "Эта группа настроек позволяет подстраивать поведение процедурных босс-уровней, если таковые включены. Не влияет на предсделанные карты. Не рекомендуется устанавливать высокие значения на слайдерах \"Дополнительные монстры\" и \"Дополнительная сложность\" одновременно, если Вам нужен сбалансированный бой."
 
 #: modules/procedural_gotcha.lua:72
 msgid "Gotcha Frequency"
-msgstr "Частота спец. уровней"
+msgstr "Частота босс-арен"
 
 #: modules/procedural_gotcha.lua:75
 msgid "Procedural Gotchas are two room maps, where the second is an immediate but immensely-sized exit room with gratitiously intensified monster strength. Essentially an arena - prepare for a tough, tough fight!\n\nNotes:\n\n5% of levels may create at least 1 or 2 gotcha maps in a standard full game."
-msgstr ""
+msgstr "Процедурные босс-арены — это карты, состоящие из двух комнат, где вторая является крайне крупной ареной с действительно усиленным монстром. Готовьтесь к изнуряющей битве!\n\nПримечание: 5% уровней означают, что за полную длину игры будут созданы одна или две таких карты."
 
 #: modules/procedural_gotcha.lua:83
 msgid "Extra Quantity"
@@ -4506,7 +4509,7 @@ msgstr "0:(НЕТ),2:2 (Сильнее),4:4 (Гораздо сильнее),6:6 
 
 #: modules/procedural_gotcha.lua:104
 msgid "Offset monster quantity from your default strength of choice plus the increasing level ramp."
-msgstr "Увеличение количества монстров в дополнение (в сумму) к текущему уровню."
+msgstr "Увеличение количества монстров в дополнение (в сумму) к текущему прогрессу сложности по игре."
 
 #: modules/procedural_gotcha.lua:111
 msgid "Map Size"
@@ -4734,11 +4737,11 @@ msgstr ""
 
 #: modules/procedural_gotcha_zdoom.lua:1687
 msgid "This module allows you to fine tune the Procedural Gotcha experience if you have Procedural Gotchas enabled. Does not affect prebuilts. It is recommended to pick higher scales on one of the two options, but not both at once for a balanced challenge."
-msgstr ""
+msgstr "Эта группа настроек позволяет подстраивать поведение процедурных босс-уровней, если таковые включены. Не влияет на предсделанные карты. Не рекомендуется устанавливать высокие значения на слайдерах \"Дополнительные монстры\" и \"Дополнительная сложность\" одновременно, если Вам нужен сбалансированный бой."
 
 #: modules/procedural_gotcha_zdoom.lua:1694
 msgid "Regular Gotcha Options"
-msgstr ""
+msgstr "Настройки босс-карт"
 
 #: modules/procedural_gotcha_zdoom.lua:1699
 msgid "Gotcha Frequency"
@@ -4794,7 +4797,7 @@ msgstr "Включить процедурных боссов"
 
 #: modules/procedural_gotcha_zdoom.lua:1769
 msgid "Toggles Boss Monster generation with special traits for Gotchas."
-msgstr ""
+msgstr "Включает или отключает генерацию боссов со своими особенностями для процедурных карт."
 
 #: modules/procedural_gotcha_zdoom.lua:1775
 msgid "Arena Steepness"
@@ -4874,7 +4877,7 @@ msgstr "Ограничение вида монстров"
 
 #: modules/procedural_gotcha_zdoom.lua:1877
 msgid "Influences how boss difficulty and megawad progression affects the monster type of boss.\n\nHard Limit: Doesn't allow monster types outside of range to ever spawn.\n\nSoft Limit: Reduces the probability of spawning of monster types outside of range.\n\nNo Limit: Difficulty doesn't have effect on monster type selection."
-msgstr "Влияет на то, как сложность босса и прогресс мегавада влияют на тип босса-монстра.\n\nЖёсткое ограничение: не позволяет появляться монстрам, которые пока что не должны появляться в последовательности уровней.\n\nМягкое ограничение: снижает вероятность появления таких монстров.\n\nБез ограждений: сложность не влияет на выбор типа монстра."
+msgstr "Влияет на то, как прогресс мегавада и сложность босса влияют на его тип.\n\nЖёсткое ограничение: не позволяет появляться монстрам, которые пока что не должны были появляться в последовательности уровней.\n\nМягкое ограничение: снижает вероятность появления таких монстров.\n\nБез ограждений: сложность не влияет на выбор типа монстра."
 
 #: modules/procedural_gotcha_zdoom.lua:1885
 msgid "Weapon placement"
@@ -5792,6 +5795,10 @@ msgstr "Архитектура"
 msgid "Level Size"
 msgstr "Размер уровней"
 
+#: modules/ui_arch.lua:128
+msgid "Mix It Up,Episodic,Progressive"
+msgstr "Случайно,По эпизодам,Постепенно"
+
 #: modules/ui_arch.lua:129
 msgid "10:10 (Microscopic),16:16 (Miniature),22:22 (Tiny),30:30 (Small),36:36 (Average),42:42 (Large),48:48 (Huge),58:58 (Colossal),66:66 (Gargantuan),75:75 (Transcendent)"
 msgstr "10:10 (Микроскопический),16:16 (Миниатюрный),22:22 (Маленький),30:30 (Небольшой),36:36 (Средний),42:42 (Крупный),48:48 (Обширный),58:58 (Огромный),66:66 (Колоссальный),75:75 (Трансцендентный)"
@@ -5814,7 +5821,7 @@ msgstr ""
 
 #: modules/ui_arch.lua:146
 msgid "Fine tune upper limit when Level Size is set to Episodic, Progressive or Mixed."
-msgstr ""
+msgstr "Тонкая подстройка максимального размера уровня, если он установлен в одно из значений \"Случайно\", \"По эпизодам\" или \"Постепенно\"."
 
 #: modules/ui_arch.lua:153
 msgid "Lower Bound"
@@ -5826,7 +5833,7 @@ msgstr ""
 
 #: modules/ui_arch.lua:160
 msgid "Fine tune lower limit when Level Size is set to Episodic, Progressive or Mixed."
-msgstr ""
+msgstr "Тонкая подстройка минимального размера уровня, если он установлен в одно из значений \"Случайно\", \"По эпизодам\" или \"Постепенно\"."
 
 #: modules/ui_arch.lua:168
 msgid "Ramp Factor"
@@ -5866,7 +5873,7 @@ msgstr "Периодически смешивает слабо выраженн�
 
 #: modules/ui_arch.lua:205
 msgid "Prebuilt Levels"
-msgstr "Добавлять предсозданные карты"
+msgstr "Предсозданные карты"
 
 #: modules/ui_arch.lua:208
 msgid "Enable or disable prebuilt maps. When disabled, are replaced with generated maps instead."
@@ -5874,19 +5881,19 @@ msgstr "Добавлять ли карты, сделанные заранее. �
 
 #: modules/ui_arch.lua:209
 msgid "Prebuilt levels are useful when, for example, a boss encounter like the Icon of Sin is desired. This sort of level would be very difficult to generate procedurally, and thus a handmade map is used instead."
-msgstr "Готовые уровни обычно полезны тогда, когда требуется встреча с боссом — к примеру, Иконой Греха. Подобный уровень было бы очень сложно сгенерировать процедурно, поэтому вместо этого используется одна из подходящих карт, сделанных вручную заранее."
+msgstr "Готовые уровни обычно полезны тогда, когда требуется встреча с боссом — к примеру, Иконой Греха. Подобный уровень довольно сложно сгенерировать процедурно, поэтому вместо них может использоваться одна из подходящих карт, сделанных вручную заранее."
 
 #: modules/ui_arch.lua:216
 msgid "Lighting Multiplier"
-msgstr "Множитель света"
+msgstr "Множитель силы света"
 
 #: modules/ui_arch.lua:225
 msgid "Adjust overall map lighting"
-msgstr "Подправить среднюю силу освещения карт"
+msgstr "Подправить среднюю силу освещения карт."
 
 #: modules/ui_arch.lua:226
 msgid "This will apply a multiplier to the values in the default lighting tables when determining the brightness level of a room. If control over the minimum or maximum brightness values is desired, please use the Minimum/Maximum Brightness sliders in the Advanced Architecture module."
-msgstr ""
+msgstr "Множитель применится к обычным значениям из таблиц освещения при определении уровня яркости комнаты. Если требуется управление минимальной и/или максимальной яркостью в целом, используйте слайдеры \"Минимальная/Максимальная яркость\" в модуле \"Расширенные настройки геометрии\"."
 
 #: modules/ui_arch.lua:230
 msgid "Outdoors"
@@ -5954,11 +5961,11 @@ msgstr "3D-скайбокс ZDoom"
 
 #: modules/ui_arch.lua:271
 msgid "Choose if 3D Skyboxes are rendered into levels and their style."
-msgstr "Генерировать ли 3D-скайбоксы. Если \"да\", то при каком условии они будут сменять друг друга."
+msgstr "Генерировать ли 3D-скайбоксы. Если \"да\", то насколько часто или при каком условии они будут сменять друг друга."
 
 #: modules/ui_arch.lua:272
 msgid "This is highly recommended when Bottomless Vistas are enabled in combination with a ZDoom Family engine."
-msgstr "Для лучшего опыта использования рекомендуется включить опцию \"Виды ниже линии горизонта\"."
+msgstr "Для лучшего опыта использования 3D-скайбоксов рекомендуется включить опцию \"Виды ниже линии горизонта\"."
 
 #: modules/ui_mons.lua:25
 msgid "NONE"
@@ -6258,7 +6265,7 @@ msgstr "Монстры в секретах"
 
 #: modules/ui_mons.lua:257
 msgid "I'm in your secret rooms, placing some monsters. Note: default is none."
-msgstr "Создавать монстров в секретных комнатах, в духе Duke Nukem 3D."
+msgstr "Создавать ли монстров в секретных комнатах, и, если \"да\", то ослаблять ли их по сравнению с общей сложностью уровня."
 
 #: modules/ui_pickups.lua:24
 msgid "NONE"
@@ -6422,11 +6429,11 @@ msgstr "Генерировать REJECT"
 
 #: modules/ui_reject_options.lua:51
 msgid "Choose to build a proper REJECT lump."
-msgstr ""
+msgstr "Создавать ли полноценный lump REJECT."
 
 #: modules/ui_reject_options.lua:52
 msgid "If this option is not selected, a blank REJECT lump with the proper size will be inserted into the map instead.\n\nThis is to prevent errors with some engines that are expecting a \"full\" REJECT lump to be present."
-msgstr ""
+msgstr "Если опция отключена, то в карту будет включён пустой lump REJECT необходимого размера. Некоторые игровые движки требуют присутствия в карте \"заполненного\" REJECT."
 
 #: modules/ui_reject_options.lua:67
 msgid "Binary"
@@ -6730,7 +6737,7 @@ msgstr "ВНИМАНИЕ! По умолчанию ZDoom-морпехи наст�
 
 #: modules/zdoom_marines.lua:244
 msgid "Default Quantity"
-msgstr "Количество:"
+msgstr "Количество"
 
 #: modules/zdoom_marines.lua:247
 msgid "Control the appearance of hostile ZDoom Marines."
@@ -7730,7 +7737,7 @@ msgstr "Игра"
 
 #: source_files/obsidian_main/ui_game.cc:178
 msgid "The following games will have gameplay that differs from the original IWADs:\n\nHexen: Game progression is linear and episodic. There are no hubs present. The Death Wyvern is not present in the monster table due to the infeasibility of scripting and flight pathing.\n\nStrife: Quests/multiple endings not yet implemented. Progression is linear and game will end on last level generated."
-msgstr ""
+msgstr "Следующие игры имеют изменения в геймплее относительно оригинальных IWAD:\n\nHexen: игра будет линейной и эпизодической, без хаб-уровней. Из-за практически невозможной сложности автоматического написания сценариев и маршрутов полёта Виверн Смерти (Death Wyvern) не будет присутствовать ни на одном уровне.\n\nStife: квесты и различающиеся концовки пока что не добавлены. Прогрессия линейна, и игра закончится на последнем сгенеррованном уровне."
 
 #: source_files/obsidian_main/ui_game.cc:183
 msgid "Engine"

--- a/source_files/obsidian_main/m_theme.cc
+++ b/source_files/obsidian_main/m_theme.cc
@@ -1493,10 +1493,12 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
     int cx = x() + kf_w(24);
     int cy = y() + (y_step * 2);
 
+	int listwidth = kf_w(160); // [McM]: Some font names was shown truncated.
+
     Fl_Box *heading;
 
     opt_window_scaling =
-        new UI_CustomMenu(cx + W * .30, cy, kf_w(130), kf_h(24), "");
+        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_window_scaling->copy_label(_("Window Scaling: "));
     opt_window_scaling->align(FL_ALIGN_LEFT);
     opt_window_scaling->add(_("AUTO|Tiny|Small|Medium|Large|Huge"));
@@ -1510,7 +1512,7 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
     cy += opt_window_scaling->h() + y_step;
 
     opt_font_scaling =
-        new Fl_Simple_Counter(cx + W * .30, cy, kf_w(130), kf_h(24), "");
+        new Fl_Simple_Counter(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_font_scaling->copy_label(_("Font Size: "));
     opt_font_scaling->align(FL_ALIGN_LEFT);
     opt_font_scaling->step(2);
@@ -1527,7 +1529,7 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
     cy += opt_font_scaling->h() + y_step;
 
     opt_font_theme =
-        new UI_CustomMenu(cx + W * .30, cy, kf_w(130), kf_h(24), "");
+        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_font_theme->copy_label(_("Font: "));
     opt_font_theme->align(FL_ALIGN_LEFT);
     opt_font_theme->callback(callback_FontTheme, this);
@@ -1543,7 +1545,7 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
     cy += opt_font_theme->h() + y_step;
 
     opt_widget_theme =
-        new UI_CustomMenu(cx + W * .30, cy, kf_w(130), kf_h(24), "");
+        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_widget_theme->copy_label(_("Widget Theme: "));
     opt_widget_theme->align(FL_ALIGN_LEFT);
     opt_widget_theme->add(_("Default|Gleam|Win95|Plastic"));
@@ -1557,7 +1559,7 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
     cy += opt_widget_theme->h() + y_step;
 
     opt_box_theme =
-        new UI_CustomMenu(cx + W * .30, cy, kf_w(130), kf_h(24), "");
+        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_box_theme->copy_label(_("Box Theme: "));
     opt_box_theme->align(FL_ALIGN_LEFT);
     opt_box_theme->add(_("Default|Shadow|Embossed|Engraved|Inverted|Raised"));
@@ -1571,7 +1573,7 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
     cy += opt_box_theme->h() + y_step;
 
     opt_button_theme =
-        new UI_CustomMenu(cx + W * .30, cy, kf_w(130), kf_h(24), "");
+        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_button_theme->copy_label(_("Button Theme: "));
     opt_button_theme->align(FL_ALIGN_LEFT);
     opt_button_theme->add(_("Default|Raised|Engraved|Embossed|Flat"));
@@ -1585,7 +1587,7 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
     cy += opt_button_theme->h() + y_step;
 
     opt_color_scheme =
-        new UI_CustomMenu(cx + W * .30, cy, kf_w(130), kf_h(24), "");
+        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_color_scheme->copy_label(_("Color Scheme: "));
     opt_color_scheme->align(FL_ALIGN_LEFT);
     opt_color_scheme->add(_("Default|Custom"));
@@ -1762,7 +1764,7 @@ UI_ThemeWin::UI_ThemeWin(int W, int H, const char *label)
 
     // restart needed warning
     heading = new Fl_Box(FL_NO_BOX, x() + pad - kf_w(5), H - dh - kf_h(3),
-                         W - pad * 2, kf_h(14),
+                         W - pad * 2, kf_h(16),
                          _("Note: Some options require a restart."));
     heading->align(FL_ALIGN_INSIDE | FL_ALIGN_CLIP);
     heading->labelsize(small_font_size);


### PR DESCRIPTION
Not translated:
  1) Not-Doom- and not-Heretic-based strings (Chex Quest, HacX, Harmony, Strife, ...);
  2) Non-critical tooltips;
  3) ZDoom marines names ("Fist marine", "Pistol marine" etc.);
  4) Something else what I missed.

Visual tweaks in the Themes menu: centered all the menus and removed bottom truncation in the note "Some options require a restart".