### PR TITLE
Fix Heretic sky generator.

### DIFF
--- a/modules/heretic/sky_generator.lua
+++ b/modules/heretic/sky_generator.lua
@@ -585,7 +585,7 @@ function SKY_GEN_HERETIC.generate_skies()
     }
 
 
-    gui.fsky_create(256, 128, 0)
+    gui.fsky_create(256, 200, 0)
 
 
     --- Clouds ---

--- a/modules/heretic/sky_generator.lua
+++ b/modules/heretic/sky_generator.lua
@@ -683,15 +683,15 @@ function SKY_GEN_HERETIC.generate_skies()
         colmap = 2,
       }
 
-      info.max_h = rand.pick({0.6, 0.65, 0.7, 0.8 })
+      info.max_h = rand.pick({0.4, 0.44, 0.48, 0.52 })
       info.min_h = rand.pick({ -0.2, -0.1 })
 
       info.frac_dim = rand.pick({1.4, 1.65, 1.8, 1.9 })
 
       if PARAM.force_hill_params == "hp_hilly" then
-        info.max_h = rand.pick({0.5, 0.55, 0.6, 0.65 })
+        info.max_h = rand.pick({0.33, 0.36, 0.39, 0.42 })
       elseif PARAM.force_hill_params == "hp_mountainous" then
-        info.max_h = rand.pick({.7, 0.75, 0.8, 0.85})
+        info.max_h = rand.pick({0.46, 0.49, 0.52, 0.55})
       elseif PARAM.force_hill_params == "hp_cavernous" then
         info.max_h = rand.pick({0.9, 1, 1.1, 1.2, 1.3})
         info.min_h = rand.pick({0, 0.1, 0.2, 0.3, 0.4, 0.5})
@@ -700,8 +700,8 @@ function SKY_GEN_HERETIC.generate_skies()
       -- sometimes make more pointy mountains
       if rand.odds(50) then
         info.power = 3.1
-        info.max_h = info.max_h + 0.1
-        info.min_h = info.min_h + 0.3
+        info.max_h = info.max_h + 0.06
+        info.min_h = info.min_h + 0.2
       end
 
       EPI.has_mountains = true

--- a/source_files/obsidian_main/dm_extra.cc
+++ b/source_files/obsidian_main/dm_extra.cc
@@ -44,7 +44,7 @@ static int sky_W;
 static int sky_H;
 static int sky_final_W;
 
-#define MAX_POST_LEN 128
+#define MAX_POST_LEN 200
 
 #define CUR_PIXEL(py) (pixels[((py) % H) * W])
 


### PR DESCRIPTION
Heretic's original renderer cannot handle the 256x128 textures produced by the sky generator. This causes issues when using a limit-removing port such as Crispy Heretic or International Heretic. This

1. Creates a sky texture at the correct size (256x200) when generating for Heretic.
2. Patches the generator to support writing the taller texture correctly.
3. Lowers the maximum terrain height somewhat (by roughly 1/3) to account for the taller sky.

[Here](https://i.imgur.com/k7Ta2iH.png) is a before and after shot, taken in a Crispy Doom devbuild. GZDoom doesn't seem to be bothered either way.

Hexen uses the same type of tall sky and Strife appears to optionally support the format. Expanding the post size helps in implementing the sky generator for these games in the future.