### PR TITLE
Fix Heretic linedef actions.

### DIFF
--- a/games/heretic/materials.lua
+++ b/games/heretic/materials.lua
@@ -258,22 +258,22 @@ HERETIC.PREFAB_FIELDS =
 {
   -- These are used for converting generic locked linedefs --
 
-  line_700 = 27,
-  line_701 = 28,
-  line_702 = 26,
+  line_700 = 27, -- Yellow key door
+  line_701 = 28, -- Green key door
+  line_702 = 26, -- Blue key door
   line_703 = 1,  -- Regular door open
   line_704 = 11, -- Switch, exit
   line_705 = 51, -- Switch, secret exit
   line_706 = 52, -- Walk-over line, exit
-  line_707 = 124, -- Walk-over line, secret exit
+  line_707 = 105, -- Walk-over line, secret exit
   line_708 = 97, -- Walk-over line, teleport
   --line_709 = 888, -- Switch (don't think I need this one)
-  line_710 = 123, -- Switched, lower lift, wait, raise (fast) -- Is this too specific? - Dasho
+  line_710 = 62, -- Switched, lower lift, wait, raise
   line_711 = 31, -- Door open stay
-  line_712 = 109, -- Walk-over, door open stay (fast)
+  line_712 = 2,  -- Walk-over, door open stay
   line_713 = 23, -- Switched, floor lower to nearest floor
   line_714 = 103, -- Switched, door open stay
-  line_715 = 126, -- Walk-over line, teleport (monsters only)
+  line_715 = 97, -- Walk-over line, teleport (monsters only) (not in Heretic, use normal teleport)
 
   -- These are used for converting generic fab things --
   thing_11000 = 2035, -- Barrel


### PR DESCRIPTION
Several of the generic actions are given incorrect values for Heretic, resulting in broken lifts, among other things.