### PR TITLE
update GH actions versions (node v16)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Install dependencies
       run: |
@@ -34,7 +34,7 @@ jobs:
       run: cmake --install build/dist
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@v3
       with:
         name: linux-x64
         path: install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -70,7 +70,7 @@ jobs:
   build-msvc:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure CMake
         run: cmake -DCMAKE_INSTALL_PREFIX=install --preset msvc
       - name: Build
@@ -78,7 +78,7 @@ jobs:
       - name: Install
         run: cmake --install build/msvc
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@v3
         with:
           name: windows-x64-msvc
           path: install


### PR DESCRIPTION
Updating github actions because we're getting a warning.