### PR TITLE
fix argv[0] segfault

### DIFF
--- a/source_files/obsidian_main/main.cc
+++ b/source_files/obsidian_main/main.cc
@@ -1371,7 +1371,7 @@ int main(int argc, char **argv) {
     argv::short_flags.emplace('u');
 
     // parse the flags
-    argv::Init(argc - 1, argv + 1);
+    argv::Init(argc, argv);
 
 hardrestart:;
 


### PR DESCRIPTION
argv was shifted so argv[0] wasn't the program name. now it is.