### PR TITLE
fix warnings, allow things needed for AUR install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,9 @@ endif()
 
 if(OBSIDIAN_INSTALL_STANDARD_LOCATION)
   set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}/share/obsidian")
+  install(FILES misc/obsidian.desktop
+          DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications"
+  )
 else()
   set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,8 @@ else()
 endif()
 
 target_include_directories(
-    obsidian SYSTEM PRIVATE source_files/filename_formatter ${CMAKE_CURRENT_BINARY_DIR}/obsidian-include
+  obsidian SYSTEM PRIVATE source_files/filename_formatter
+                          ${CMAKE_CURRENT_BINARY_DIR}/obsidian-include
 )
 if(NOT CONSOLE_ONLY AND NOT HAIKU)
   target_include_directories(obsidian SYSTEM PRIVATE source_files/fltk)
@@ -259,7 +260,10 @@ if(UNIX)
   endif()
 endif()
 
-target_link_libraries(obsidian PRIVATE fmt::fmt-header-only hedley::hedley spdlog::spdlog_header_only)
+target_link_libraries(
+  obsidian PRIVATE fmt::fmt-header-only hedley::hedley
+                   spdlog::spdlog_header_only
+)
 
 # Copies executables to local install directory after build
 add_custom_command(
@@ -293,13 +297,8 @@ if(UNIX)
       )
     else()
       target_link_libraries(
-        obsidian
-        PRIVATE filename_formatter
-                miniz
-                libluajit
-                physfs-static
-                obsidian_zdbsp
-                obsidian_slump
+        obsidian PRIVATE filename_formatter miniz libluajit physfs-static
+                         obsidian_zdbsp obsidian_slump
       )
     endif()
   elseif(${CMAKE_SYSTEM} MATCHES "BSD")
@@ -317,13 +316,8 @@ if(UNIX)
       )
     else()
       target_link_libraries(
-        obsidian
-        PRIVATE filename_formatter
-                miniz
-                libluajit
-                physfs-static
-                obsidian_zdbsp
-                obsidian_slump
+        obsidian PRIVATE filename_formatter miniz libluajit physfs-static
+                         obsidian_zdbsp obsidian_slump
       )
     endif()
   elseif(HAIKU)
@@ -351,7 +345,7 @@ if(UNIX)
                 physfs-static
                 obsidian_zdbsp
                 obsidian_slump
-		${FONTCONFIG}
+                ${FONTCONFIG}
                 pthread
       )
     else()
@@ -382,21 +376,22 @@ else()
     )
   else()
     target_link_libraries(
-      obsidian
-      PRIVATE filename_formatter
-              miniz
-              libluajit
-              physfs-static
-              obsidian_zdbsp
-              obsidian_slump
+      obsidian PRIVATE filename_formatter miniz libluajit physfs-static
+                       obsidian_zdbsp obsidian_slump
     )
   endif()
 endif()
 
-install(TARGETS obsidian RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
+if(OBSIDIAN_INSTALL_STANDARD_LOCATION)
+  set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}/share/obsidian")
+else()
+  set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}")
+endif()
+
+install(TARGETS obsidian RUNTIME DESTINATION ${INSTALL_BASEDIR}
                                  CONFIGURATIONS Release
 )
-install(TARGETS qsavetex RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/tools
+install(TARGETS qsavetex RUNTIME DESTINATION ${INSTALL_BASEDIR}/tools
                                  CONFIGURATIONS Release
 )
 install(
@@ -410,6 +405,6 @@ install(
             scripts
             theme
             tools
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION ${INSTALL_BASEDIR}
   CONFIGURATIONS Release
 )

--- a/misc/obsidian.desktop
+++ b/misc/obsidian.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Obsidian Level Maker
+Comment=Generate random levels for classic FPS games (DOOM etc)
+Exec=/usr/share/obsidian/obsidian
+Icon=obsidian
+Terminal=false
+Type=Application
+Categories=Game;ActionGame;
+StartupNotify=false

--- a/misc/obsidian.desktop
+++ b/misc/obsidian.desktop
@@ -2,6 +2,7 @@
 Name=Obsidian Level Maker
 Comment=Generate random levels for classic FPS games (DOOM etc)
 Exec=/usr/share/obsidian/obsidian
+Path=/usr/share/obsidian
 Icon=obsidian
 Terminal=false
 Type=Application

--- a/misc/obsidian.desktop
+++ b/misc/obsidian.desktop
@@ -1,8 +1,7 @@
 [Desktop Entry]
 Name=Obsidian Level Maker
 Comment=Generate random levels for classic FPS games (DOOM etc)
-Exec=/usr/share/obsidian/obsidian
-Path=/usr/share/obsidian
+Exec=/usr/share/obsidian/obsidian --install /usr/share/obsidian
 Icon=obsidian
 Terminal=false
 Type=Application

--- a/source_files/obsidian_main/m_dialog.cc
+++ b/source_files/obsidian_main/m_dialog.cc
@@ -314,17 +314,18 @@ std::filesystem::path DLG_OutputFilename(const char *ext, const char *preset) {
 void DLG_EditSeed(void) {
     ;
 
-    const char *user_buf =
-        fl_input(_("Enter New Seed Number or Phrase:"),
-                 string_seed.empty() ? std::to_string(next_rand_seed).c_str()
-                                     : string_seed.c_str());
+    int user_response;
+    Fl_String user_buf = fl_input_str(
+        user_response, 0 /* limit */, _("Enter New Seed Number or Phrase:"),
+        string_seed.empty() ? std::to_string(next_rand_seed).c_str()
+                            : string_seed.c_str());
 
     // cancelled?
-    if (!user_buf) {
+    if (user_response < 0) {
         return;
     }
 
-    std::string word = user_buf;
+    std::string word = {user_buf.c_str(), static_cast<size_t>(user_buf.size())};
     try {
         for (long unsigned int i = 0; i < word.size(); i++) {
             char character = word.at(i);
@@ -349,9 +350,9 @@ void DLG_EditSeed(void) {
     }
     string_seed = word;
     ob_set_config("string_seed", word.c_str());
-    unsigned long long split_limit =
-        (std::numeric_limits<long long>::max() /
-         127);  // It is intentional that I am using the max for signed - Dasho
+    unsigned long long split_limit = (std::numeric_limits<long long>::max() /
+                                      127);  // It is intentional that I am
+                                             // using the max for signed - Dasho
     next_rand_seed = split_limit;
     for (size_t i = 0; i < word.size(); i++) {
         char character = word.at(i);
@@ -739,7 +740,6 @@ UI_GlossaryViewer::UI_GlossaryViewer(int W, int H, const char *l)
 UI_GlossaryViewer::~UI_GlossaryViewer() {}
 
 void UI_GlossaryViewer::ReadGlossary() {
-
     std::string glossary =
         fmt::format("{}/language/{}.txt", install_dir.string(), selected_lang);
 

--- a/source_files/obsidian_main/m_dialog.cc
+++ b/source_files/obsidian_main/m_dialog.cc
@@ -316,9 +316,10 @@ void DLG_EditSeed(void) {
 
     int user_response;
     Fl_String user_buf = fl_input_str(
-        user_response, 0 /* limit */, _("Enter New Seed Number or Phrase:"),
+        user_response, 0 /* limit */, "%s",
         string_seed.empty() ? std::to_string(next_rand_seed).c_str()
-                            : string_seed.c_str());
+                            : string_seed.c_str(),
+        _("Enter New Seed Number or Phrase:"));
 
     // cancelled?
     if (user_response < 0) {

--- a/source_files/obsidian_main/m_options.cc
+++ b/source_files/obsidian_main/m_options.cc
@@ -443,8 +443,8 @@ class UI_OptionsWin : public Fl_Window {
         UI_OptionsWin *that = (UI_OptionsWin *)data;
         if (that->opt_limit_break->value()) {
             // clang-format off
-            if (fl_choice("%s", 
-                        _("Cancel"), 
+            if (fl_choice("%s",
+                        _("Cancel"),
                         _("Yes, break Obsidian"), 0,
                 _("WARNING! This option will allow you to manually enter values in excess of the \n(usually) stable slider limits for Obsidian.\nAny bugs, crashes, or errors as a result of this will not be addressed by the developers.\nYou must select Yes for this option to be applied."))) {
                 // clang-format on

--- a/source_files/obsidian_main/m_options.cc
+++ b/source_files/obsidian_main/m_options.cc
@@ -443,9 +443,10 @@ class UI_OptionsWin : public Fl_Window {
         UI_OptionsWin *that = (UI_OptionsWin *)data;
         if (that->opt_limit_break->value()) {
             // clang-format off
-            if (fl_choice(_("WARNING! This option will allow you to manually enter values in excess of the \n(usually) stable slider limits for Obsidian.\nAny bugs, crashes, or errors as a result of this will not be addressed by the developers.\nYou must select Yes for this option to be applied."),
-                          _("Cancel"), 
-                          _("Yes, break Obsidian"), 0)) {
+            if (fl_choice("%s", 
+                        _("Cancel"), 
+                        _("Yes, break Obsidian"), 0,
+                _("WARNING! This option will allow you to manually enter values in excess of the \n(usually) stable slider limits for Obsidian.\nAny bugs, crashes, or errors as a result of this will not be addressed by the developers.\nYou must select Yes for this option to be applied."))) {
                 // clang-format on
                 limit_break = true;
             } else {
@@ -543,10 +544,13 @@ class UI_OptionsWin : public Fl_Window {
 #endif
         UI_OptionsWin *that = (UI_OptionsWin *)data;
         std::string blanker;
-        blanker.append(250,' ');
+        blanker.append(250, ' ');
         that->opt_current_output_path->copy_label(blanker.c_str());
         that->opt_current_output_path->redraw_label();
-        that->opt_current_output_path->copy_label(fmt::format("{}: {}", _("Current Path"), BestDirectory().generic_string()).c_str());
+        that->opt_current_output_path->copy_label(
+            fmt::format("{}: {}", _("Current Path"),
+                        BestDirectory().generic_string())
+                .c_str());
         that->opt_current_output_path->redraw_label();
     }
 };
@@ -573,8 +577,7 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     Fl_Box *heading;
 
-    opt_language =
-        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_language = new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_language->copy_label(_("Language: "));
     opt_language->align(FL_ALIGN_LEFT);
     opt_language->callback(callback_Language, this);
@@ -633,9 +636,9 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_default_output_path->h() + y_step;
 
-    opt_current_output_path = new Fl_Box(
-        cx, cy, W - cx - pad, kf_h(36), "");
-    opt_current_output_path->align(FL_ALIGN_INSIDE | FL_ALIGN_CENTER | FL_ALIGN_WRAP);
+    opt_current_output_path = new Fl_Box(cx, cy, W - cx - pad, kf_h(36), "");
+    opt_current_output_path->align(FL_ALIGN_INSIDE | FL_ALIGN_CENTER |
+                                   FL_ALIGN_WRAP);
     opt_current_output_path->visible_focus(0);
     opt_current_output_path->color(BUTTON_COLOR);
     opt_current_output_path->labelfont(font_style);
@@ -697,7 +700,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_mature_words->h() + y_step * .5;
 
-    opt_backups = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_backups =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_backups->copy_label(_(" Create Backups"));
     opt_backups->value(create_backups ? 1 : 0);
     opt_backups->callback(callback_Backups, this);
@@ -707,7 +711,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_backups->h() + y_step * .5;
 
-    opt_overwrite = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_overwrite =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_overwrite->copy_label(_(" Overwrite File Warning"));
     opt_overwrite->value(overwrite_warning ? 1 : 0);
     opt_overwrite->callback(callback_Overwrite, this);
@@ -717,7 +722,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_overwrite->h() + y_step * .5;
 
-    opt_debug = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_debug =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_debug->copy_label(_(" Debugging Messages"));
     opt_debug->value(debug_messages ? 1 : 0);
     opt_debug->callback(callback_Debug, this);
@@ -727,7 +733,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_debug->h() + y_step * .5;
 
-    opt_limit_break = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_limit_break =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_limit_break->copy_label(_(" Ignore Slider Limits"));
     opt_limit_break->value(limit_break ? 1 : 0);
     opt_limit_break->callback(callback_LimitBreak, this);

--- a/source_files/obsidian_main/ui_module.cc
+++ b/source_files/obsidian_main/ui_module.cc
@@ -96,9 +96,8 @@ void UI_Module::AddHeader(std::string opt, std::string label, int gap) {
     UI_RHeader *rhead = new UI_RHeader(nx, ny + kf_h(15), nw * .95,
                                        (!single_pane ? kf_h(48) : kf_h(24)));
 
-    rhead->mod_label = new Fl_Box(
-        rhead->x(), rhead->y(),
-        rhead->w() * .95, kf_h(24), "");
+    rhead->mod_label =
+        new Fl_Box(rhead->x(), rhead->y(), rhead->w() * .95, kf_h(24), "");
     rhead->mod_label->copy_label(label.c_str());
     rhead->mod_label->align(
         (!single_pane ? (FL_ALIGN_CENTER | FL_ALIGN_INSIDE)
@@ -333,15 +332,15 @@ void UI_Module::AddSliderOption(std::string opt, std::string label,
     oldpos = 0;
     pos = 0;
 #ifdef __APPLE__
-        setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C");
 #elif __unix__
 #ifndef __linux__
-        setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C");
 #else
-        std::setlocale(LC_NUMERIC, "C");
+    std::setlocale(LC_NUMERIC, "C");
 #endif
 #else
-        std::setlocale(LC_NUMERIC, "C");
+    std::setlocale(LC_NUMERIC, "C");
 #endif
 
     while (pos != std::string::npos) {
@@ -374,15 +373,15 @@ void UI_Module::AddSliderOption(std::string opt, std::string label,
         }
     }
 #ifdef __APPLE__
-        setlocale(LC_NUMERIC, numeric_locale.c_str());
+    setlocale(LC_NUMERIC, numeric_locale.c_str());
 #elif __unix__
 #ifndef __linux__
-        setlocale(LC_NUMERIC, numeric_locale.c_str());
+    setlocale(LC_NUMERIC, numeric_locale.c_str());
 #else
-        std::setlocale(LC_NUMERIC, numeric_locale.c_str());
+    std::setlocale(LC_NUMERIC, numeric_locale.c_str());
 #endif
 #else
-        std::setlocale(LC_NUMERIC, numeric_locale.c_str());
+    std::setlocale(LC_NUMERIC, numeric_locale.c_str());
 #endif
 
     rsl->cb_data = new opt_change_callback_data_t;
@@ -905,7 +904,8 @@ void UI_Module::callback_ManualEntry(Fl_Widget *w, void *data) {
 
 tryagain:
 
-    const char *value_buf = fl_input(_("Enter Value:"), float_buf.c_str());
+    const char *value_buf =
+        fl_input("%s", float_buf.c_str(), _("Enter Value:"));
 
     // cancelled?
     if (!value_buf) {


### PR DESCRIPTION
- attempt to fix -Werror=format-security warning
- really fix that warning
- fix the same issue in m_options.cc
- clean up whitespace in clang-format disabled spot
- whack a mole
- format and allow customizing output dir more
- add desktop file
