### PR TITLE
Pull install support from stable branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,11 +246,6 @@ if(UNIX)
   endif()
 endif()
 
-target_link_libraries(
-  obsidian PRIVATE fmt::fmt-header-only hedley::hedley
-                   spdlog::spdlog_header_only
-)
-
 # Copies executables to local install directory after build
 add_custom_command(
   TARGET obsidian
@@ -284,19 +279,8 @@ if(UNIX)
       )
     else()
       target_link_libraries(
-<<<<<<< HEAD
-        obsidian
-        PRIVATE ajbsp
-                ajparse
-                filename_formatter
-                miniz
-                libluajit
-                physfs-static
-                obsidian_slump
-=======
         obsidian PRIVATE filename_formatter miniz libluajit physfs-static
                          obsidian_zdbsp obsidian_slump
->>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
       )
     endif()
   elseif(${CMAKE_SYSTEM} MATCHES "BSD")
@@ -315,19 +299,8 @@ if(UNIX)
       )
     else()
       target_link_libraries(
-<<<<<<< HEAD
-        obsidian
-        PRIVATE ajbsp
-                ajparse
-                filename_formatter
-                miniz
-                libluajit
-                physfs-static
-                obsidian_slump
-=======
         obsidian PRIVATE filename_formatter miniz libluajit physfs-static
                          obsidian_zdbsp obsidian_slump
->>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
       )
     endif()
   elseif(HAIKU)
@@ -357,11 +330,7 @@ if(UNIX)
                 libluajit
                 physfs-static
                 obsidian_slump
-<<<<<<< HEAD
                 fontconfig
-=======
-                ${FONTCONFIG}
->>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
                 pthread
       )
     else()
@@ -394,19 +363,8 @@ else()
     )
   else()
     target_link_libraries(
-<<<<<<< HEAD
-      obsidian
-      PRIVATE ajbsp
-              ajparse
-              filename_formatter
-              miniz
-              libluajit
-              physfs-static
-              obsidian_slump
-=======
       obsidian PRIVATE filename_formatter miniz libluajit physfs-static
                        obsidian_zdbsp obsidian_slump
->>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
     )
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,9 @@ endif()
 
 if(OBSIDIAN_INSTALL_STANDARD_LOCATION)
   set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}/share/obsidian")
+  install(FILES misc/obsidian.desktop
+          DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications"
+  )
 else()
   set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ target_include_directories(obsidian SYSTEM PRIVATE source_files/ajbsp)
 target_include_directories(obsidian SYSTEM PRIVATE source_files/ajparse)
 target_include_directories(
   obsidian SYSTEM PRIVATE source_files/filename_formatter
+                          ${CMAKE_CURRENT_BINARY_DIR}/obsidian-include
 )
 if(NOT CONSOLE_ONLY AND NOT HAIKU)
   target_include_directories(obsidian SYSTEM PRIVATE source_files/fltk)
@@ -245,6 +246,11 @@ if(UNIX)
   endif()
 endif()
 
+target_link_libraries(
+  obsidian PRIVATE fmt::fmt-header-only hedley::hedley
+                   spdlog::spdlog_header_only
+)
+
 # Copies executables to local install directory after build
 add_custom_command(
   TARGET obsidian
@@ -278,6 +284,7 @@ if(UNIX)
       )
     else()
       target_link_libraries(
+<<<<<<< HEAD
         obsidian
         PRIVATE ajbsp
                 ajparse
@@ -286,6 +293,10 @@ if(UNIX)
                 libluajit
                 physfs-static
                 obsidian_slump
+=======
+        obsidian PRIVATE filename_formatter miniz libluajit physfs-static
+                         obsidian_zdbsp obsidian_slump
+>>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
       )
     endif()
   elseif(${CMAKE_SYSTEM} MATCHES "BSD")
@@ -304,6 +315,7 @@ if(UNIX)
       )
     else()
       target_link_libraries(
+<<<<<<< HEAD
         obsidian
         PRIVATE ajbsp
                 ajparse
@@ -312,6 +324,10 @@ if(UNIX)
                 libluajit
                 physfs-static
                 obsidian_slump
+=======
+        obsidian PRIVATE filename_formatter miniz libluajit physfs-static
+                         obsidian_zdbsp obsidian_slump
+>>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
       )
     endif()
   elseif(HAIKU)
@@ -341,7 +357,11 @@ if(UNIX)
                 libluajit
                 physfs-static
                 obsidian_slump
+<<<<<<< HEAD
                 fontconfig
+=======
+                ${FONTCONFIG}
+>>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
                 pthread
       )
     else()
@@ -374,6 +394,7 @@ else()
     )
   else()
     target_link_libraries(
+<<<<<<< HEAD
       obsidian
       PRIVATE ajbsp
               ajparse
@@ -382,14 +403,24 @@ else()
               libluajit
               physfs-static
               obsidian_slump
+=======
+      obsidian PRIVATE filename_formatter miniz libluajit physfs-static
+                       obsidian_zdbsp obsidian_slump
+>>>>>>> 6ee6cbd0e (format and allow customizing output dir more)
     )
   endif()
 endif()
 
-install(TARGETS obsidian RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
+if(OBSIDIAN_INSTALL_STANDARD_LOCATION)
+  set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}/share/obsidian")
+else()
+  set(INSTALL_BASEDIR "${CMAKE_INSTALL_PREFIX}")
+endif()
+
+install(TARGETS obsidian RUNTIME DESTINATION ${INSTALL_BASEDIR}
                                  CONFIGURATIONS Release
 )
-install(TARGETS qsavetex RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/tools
+install(TARGETS qsavetex RUNTIME DESTINATION ${INSTALL_BASEDIR}/tools
                                  CONFIGURATIONS Release
 )
 install(
@@ -403,6 +434,6 @@ install(
             scripts
             theme
             tools
-  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  DESTINATION ${INSTALL_BASEDIR}
   CONFIGURATIONS Release
 )

--- a/misc/obsidian.desktop
+++ b/misc/obsidian.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Obsidian Level Maker
+Comment=Generate random levels for classic FPS games (DOOM etc)
+Exec=/usr/share/obsidian/obsidian
+Icon=obsidian
+Terminal=false
+Type=Application
+Categories=Game;ActionGame;
+StartupNotify=false

--- a/misc/obsidian.desktop
+++ b/misc/obsidian.desktop
@@ -2,6 +2,7 @@
 Name=Obsidian Level Maker
 Comment=Generate random levels for classic FPS games (DOOM etc)
 Exec=/usr/share/obsidian/obsidian
+Path=/usr/share/obsidian
 Icon=obsidian
 Terminal=false
 Type=Application

--- a/misc/obsidian.desktop
+++ b/misc/obsidian.desktop
@@ -1,8 +1,7 @@
 [Desktop Entry]
 Name=Obsidian Level Maker
 Comment=Generate random levels for classic FPS games (DOOM etc)
-Exec=/usr/share/obsidian/obsidian
-Path=/usr/share/obsidian
+Exec=/usr/share/obsidian/obsidian --install /usr/share/obsidian
 Icon=obsidian
 Terminal=false
 Type=Application

--- a/source_files/obsidian_main/m_dialog.cc
+++ b/source_files/obsidian_main/m_dialog.cc
@@ -279,7 +279,8 @@ std::filesystem::path DLG_OutputFilename(const char *ext, const char *preset) {
             break;  // OK
     }
 
-    std::filesystem::path src_name = std::filesystem::u8path(chooser.filename());
+    std::filesystem::path src_name =
+        std::filesystem::u8path(chooser.filename());
 
     std::filesystem::path dir_name = src_name.parent_path();
 
@@ -309,21 +310,23 @@ std::filesystem::path DLG_OutputFilename(const char *ext, const char *preset) {
 void DLG_EditSeed(void) {
     ;
 
-    const char *user_buf =
-        fl_input(_("Enter New Seed Number or Phrase:"),
-                 string_seed.empty() ? std::to_string(next_rand_seed).c_str()
-                                     : string_seed.c_str());
+    int user_response;
+    Fl_String user_buf = fl_input_str(
+        user_response, 0 /* limit */, "%s",
+        string_seed.empty() ? std::to_string(next_rand_seed).c_str()
+                            : string_seed.c_str(),
+        _("Enter New Seed Number or Phrase:"));
 
     // cancelled?
-    if (!user_buf) {
+    if (user_response < 0) {
         return;
     }
 
-    std::string word = user_buf;
+    std::string word = {user_buf.c_str(), static_cast<size_t>(user_buf.size())};
     try {
         for (long unsigned int i = 0; i < word.size(); i++) {
             char character = word.at(i);
-            if (!std::isdigit(character)) {
+            if (not std::isdigit(character)) {
                 throw std::runtime_error(
                     // clang-format off
                     _("String contains non-digits. Will process as string\n"));
@@ -613,7 +616,8 @@ tryagain:;
             break;  // OK
     }
 
-    std::filesystem::path filename = std::filesystem::u8path(chooser.filename());
+    std::filesystem::path filename =
+        std::filesystem::u8path(chooser.filename());
 
     // add an extension if missing
     if (!filename.has_extension()) {
@@ -736,9 +740,9 @@ UI_GlossaryViewer::UI_GlossaryViewer(int W, int H, const char *l)
 UI_GlossaryViewer::~UI_GlossaryViewer() {}
 
 void UI_GlossaryViewer::ReadGlossary() {
-
-    std::filesystem::path glossary =
-        std::filesystem::u8path(StringFormat("%s/language/%s.txt", install_dir.u8string().c_str(), selected_lang.c_str()));
+    std::filesystem::path glossary = std::filesystem::u8path(
+        StringFormat("%s/language/%s.txt", install_dir.u8string().c_str(),
+                     selected_lang.c_str()));
 
     if (!std::filesystem::exists(glossary)) {
         return;

--- a/source_files/obsidian_main/m_options.cc
+++ b/source_files/obsidian_main/m_options.cc
@@ -176,7 +176,9 @@ bool Options_Save(std::filesystem::path filename) {
     option_fp << "mature_word_lists = " << (mature_word_lists ? 1 : 0) << "\n";
     option_fp << "filename_prefix = " << filename_prefix << "\n";
     option_fp << "custom_prefix = " << custom_prefix << "\n";
-    std::string dop = StringFormat("default_output_path = %s\n", StringToUTF8(default_output_path.generic_u16string()).c_str());
+    std::string dop = StringFormat(
+        "default_output_path = %s\n",
+        StringToUTF8(default_output_path.generic_u16string()).c_str());
     option_fp.write(dop.c_str(), dop.size());
     option_fp << "builds_per_run = " << builds_per_run << "\n";
 
@@ -412,9 +414,10 @@ class UI_OptionsWin : public Fl_Window {
         UI_OptionsWin *that = (UI_OptionsWin *)data;
         if (that->opt_limit_break->value()) {
             // clang-format off
-            if (fl_choice(_("WARNING! This option will allow you to manually enter values in excess of the \n(usually) stable slider limits for Obsidian.\nAny bugs, crashes, or errors as a result of this will not be addressed by the developers.\nYou must select Yes for this option to be applied."),
-                          _("Cancel"), 
-                          _("Yes, break Obsidian"), 0)) {
+            if (fl_choice("%s", 
+                        _("Cancel"), 
+                        _("Yes, break Obsidian"), 0,
+                _("WARNING! This option will allow you to manually enter values in excess of the \n(usually) stable slider limits for Obsidian.\nAny bugs, crashes, or errors as a result of this will not be addressed by the developers.\nYou must select Yes for this option to be applied."))) {
                 // clang-format on
                 limit_break = true;
             } else {
@@ -499,7 +502,8 @@ class UI_OptionsWin : public Fl_Window {
                 break;  // OK
         }
 
-        std::filesystem::path dir_name = std::filesystem::u8path(chooser.filename());
+        std::filesystem::path dir_name =
+            std::filesystem::u8path(chooser.filename());
 
         if (dir_name.empty()) {
             LogPrintf(_("Empty default directory provided???:\n"));
@@ -509,10 +513,13 @@ class UI_OptionsWin : public Fl_Window {
         default_output_path = dir_name;
         UI_OptionsWin *that = (UI_OptionsWin *)data;
         std::string blanker;
-        blanker.append(250,' ');
+        blanker.append(250, ' ');
         that->opt_current_output_path->copy_label(blanker.c_str());
         that->opt_current_output_path->redraw_label();
-        that->opt_current_output_path->copy_label(StringFormat("%s: %s", _("Current Path"), BestDirectory().u8string().c_str()).c_str());
+        that->opt_current_output_path->copy_label(
+            fmt::format("{}: {}", _("Current Path"),
+                        BestDirectory().generic_string())
+                .c_str());
         that->opt_current_output_path->redraw_label();
     }
 };
@@ -537,8 +544,7 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     int listwidth = kf_w(160);
 
-    opt_language =
-        new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_language = new UI_CustomMenu(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_language->copy_label(_("Language: "));
     opt_language->align(FL_ALIGN_LEFT);
     opt_language->callback(callback_Language, this);
@@ -597,9 +603,9 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_default_output_path->h() + y_step;
 
-    opt_current_output_path = new Fl_Box(
-        cx, cy, W - cx - pad, kf_h(36), "");
-    opt_current_output_path->align(FL_ALIGN_INSIDE | FL_ALIGN_CENTER | FL_ALIGN_WRAP);
+    opt_current_output_path = new Fl_Box(cx, cy, W - cx - pad, kf_h(36), "");
+    opt_current_output_path->align(FL_ALIGN_INSIDE | FL_ALIGN_CENTER |
+                                   FL_ALIGN_WRAP);
     opt_current_output_path->visible_focus(0);
     opt_current_output_path->color(BUTTON_COLOR);
     opt_current_output_path->labelfont(font_style);
@@ -661,7 +667,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_mature_words->h() + y_step * .5;
 
-    opt_backups = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_backups =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_backups->copy_label(_(" Create Backups"));
     opt_backups->value(create_backups ? 1 : 0);
     opt_backups->callback(callback_Backups, this);
@@ -671,7 +678,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_backups->h() + y_step * .5;
 
-    opt_overwrite = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_overwrite =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_overwrite->copy_label(_(" Overwrite File Warning"));
     opt_overwrite->value(overwrite_warning ? 1 : 0);
     opt_overwrite->callback(callback_Overwrite, this);
@@ -681,7 +689,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_overwrite->h() + y_step * .5;
 
-    opt_debug = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_debug =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_debug->copy_label(_(" Debugging Messages"));
     opt_debug->value(debug_messages ? 1 : 0);
     opt_debug->callback(callback_Debug, this);
@@ -691,7 +700,8 @@ UI_OptionsWin::UI_OptionsWin(int W, int H, const char *label)
 
     cy += opt_debug->h() + y_step * .5;
 
-    opt_limit_break = new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
+    opt_limit_break =
+        new UI_CustomCheckBox(cx + W * .38, cy, listwidth, kf_h(24), "");
     opt_limit_break->copy_label(_(" Ignore Slider Limits"));
     opt_limit_break->value(limit_break ? 1 : 0);
     opt_limit_break->callback(callback_LimitBreak, this);

--- a/source_files/obsidian_main/m_options.cc
+++ b/source_files/obsidian_main/m_options.cc
@@ -414,8 +414,8 @@ class UI_OptionsWin : public Fl_Window {
         UI_OptionsWin *that = (UI_OptionsWin *)data;
         if (that->opt_limit_break->value()) {
             // clang-format off
-            if (fl_choice("%s", 
-                        _("Cancel"), 
+            if (fl_choice("%s",
+                        _("Cancel"),
                         _("Yes, break Obsidian"), 0,
                 _("WARNING! This option will allow you to manually enter values in excess of the \n(usually) stable slider limits for Obsidian.\nAny bugs, crashes, or errors as a result of this will not be addressed by the developers.\nYou must select Yes for this option to be applied."))) {
                 // clang-format on

--- a/source_files/obsidian_main/m_options.cc
+++ b/source_files/obsidian_main/m_options.cc
@@ -517,8 +517,8 @@ class UI_OptionsWin : public Fl_Window {
         that->opt_current_output_path->copy_label(blanker.c_str());
         that->opt_current_output_path->redraw_label();
         that->opt_current_output_path->copy_label(
-            fmt::format("{}: {}", _("Current Path"),
-                        BestDirectory().generic_string())
+            StringFormat("%s: %s", _("Current Path"),
+                         BestDirectory().u8string().c_str())
                 .c_str());
         that->opt_current_output_path->redraw_label();
     }

--- a/source_files/obsidian_main/ui_module.cc
+++ b/source_files/obsidian_main/ui_module.cc
@@ -95,9 +95,8 @@ void UI_Module::AddHeader(std::string opt, std::string label, int gap) {
 
     UI_RHeader *rhead = new UI_RHeader(nx, ny + kf_h(15), nw * .95, kf_h(24));
 
-    rhead->mod_label = new Fl_Box(
-        rhead->x(), rhead->y(),
-        rhead->w() * .95, kf_h(24), "");
+    rhead->mod_label =
+        new Fl_Box(rhead->x(), rhead->y(), rhead->w() * .95, kf_h(24), "");
     rhead->mod_label->copy_label(label.c_str());
     rhead->mod_label->align((FL_ALIGN_CENTER | FL_ALIGN_INSIDE | FL_ALIGN_CLIP));
     rhead->mod_label->labelfont(font_style + 1);
@@ -356,15 +355,15 @@ void UI_Module::AddSliderOption(std::string opt, std::string label,
     oldpos = 0;
     pos = 0;
 #ifdef __APPLE__
-        setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C");
 #elif __unix__
 #ifndef __linux__
-        setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C");
 #else
-        std::setlocale(LC_NUMERIC, "C");
+    std::setlocale(LC_NUMERIC, "C");
 #endif
 #else
-        std::setlocale(LC_NUMERIC, "C");
+    std::setlocale(LC_NUMERIC, "C");
 #endif
 
     while (pos != std::string::npos) {
@@ -397,15 +396,15 @@ void UI_Module::AddSliderOption(std::string opt, std::string label,
         }
     }
 #ifdef __APPLE__
-        setlocale(LC_NUMERIC, numeric_locale.c_str());
+    setlocale(LC_NUMERIC, numeric_locale.c_str());
 #elif __unix__
 #ifndef __linux__
-        setlocale(LC_NUMERIC, numeric_locale.c_str());
+    setlocale(LC_NUMERIC, numeric_locale.c_str());
 #else
-        std::setlocale(LC_NUMERIC, numeric_locale.c_str());
+    std::setlocale(LC_NUMERIC, numeric_locale.c_str());
 #endif
 #else
-        std::setlocale(LC_NUMERIC, numeric_locale.c_str());
+    std::setlocale(LC_NUMERIC, numeric_locale.c_str());
 #endif
 
     rsl->cb_data = new opt_change_callback_data_t;
@@ -942,7 +941,8 @@ void UI_Module::callback_ManualEntry(Fl_Widget *w, void *data) {
 
 tryagain:
 
-    const char *value_buf = fl_input(_("Enter Value:"), float_buf.c_str());
+    const char *value_buf =
+        fl_input("%s", float_buf.c_str(), _("Enter Value:"));
 
     // cancelled?
     if (!value_buf) {


### PR DESCRIPTION
- really fix that warning
- fix the same issue in m_options.cc
- clean up whitespace in clang-format disabled spot
- whack a mole
- format and allow customizing output dir more
- add desktop file
- add Path= to desktop entry just in case
- this argument is helpful since the previous thing didn't work
- fix unfinished business merging from stable
