### PR TITLE
WIP Hacx SLUMP improvements

### DIFF
--- a/games/hacx/themes.lua
+++ b/games/hacx/themes.lua
@@ -87,7 +87,8 @@ HACX.THEMES =
       ; used on secret levels.  There should be at least one "secret"
       ; theme.
 
-	  Theme CYB ; "Cyberspace" theme
+	  Theme PRS ; Prison theme
+	  Theme OTA ; Digi-Ota theme
 
       ; Flats and textures and constructs and stuff are also in the [THEMES] section
 
@@ -117,113 +118,124 @@ HACX.THEMES =
       ;    divisor of 256 (except for doors, where you should give the real
       ;    width so SLIGE can make them look nice).
 
-	  ; Cyb walls
-	  Texture BRICK10 size 128 128 wall core CYB
-	  Texture ASHWALL2 size 128 128 wall core CYB subtle TEKWALL1
-    Texture COMPUTE2 size 128 128 wall core CYB
-	  Texture BROWNHUG size 64 128 wall core CYB subtle BROWN96
-    Texture BROWNPIP size 128 128 wall core CYB
-    Texture STONE2 size 128 128 wall core CYB
-    Texture STONE size 128 128 wall core CYB
-    Texture BRNSMAL1 size 128 128 wall core CYB subtle BRNSMALL
+	  ; Prison walls
+	  Texture MIDSPACE size 128 128 wall core PRS
+	  Texture METAL6 size 128 128 wall core PRS subtle METAL5
+	  Texture MIDBARS1 size 128 128 wall core PRS subtle METAL7
+	  
+	  ; Prison switches
+	  Texture SW1STARG size 128 128 isswitch comp PRS comp OTA
+	  Texture SW1BRNGN size 128 128 isswitch comp PRS comp OTA
+	  
+	  ; Digi-Ota walls
+	  Texture HW165 size 128 128 wall core OTA
+	  Texture STUCCO2 size 128 128 wall core OTA
+	  Texture TANROCK2 size 128 128 wall core OTA
 
-	  ; Cyb switches
-	  Texture SW1BRNGN size 128 128 ybias 82 isswitch comp CYB
+	  ; And the lift texture
+	  Texture BIGDOOR1 size 128 128 lift comp PRS comp OTA
 
-    ; And the lift texture
-    Texture BIGDOOR1 size 128 128 lift comp CYB
+	  ; Doors of all kinds.  "size" gives the width and height of the texture,
+	  ; and "locked" means that it's a good texture to use on a door that only
+	  ; opens with a switch, not a touch.
+	  Texture BIGDOOR4 size 128 128 door comp PRS comp OTA
 
-    ; Doors of all kinds.  "size" gives the width and height of the texture,
-    ; and "locked" means that it's a good texture to use on a door that only
-    ; opens with a switch, not a touch.
-    Texture BIGDOOR2 size 128 128 door comp CYB
+	  ; Prison exit switches
+	  Texture DOORRED size 128 128 exitswitch comp PRS comp OTA
 
-	  ; Cyb exit switches
-	  Texture DOORRED size 128 128 exitswitch comp CYB
+	  ; Lights, suitable for lighting recesses and stuff.
+	  Texture HW208 size 8 64 light comp PRS comp OTA
+	  Texture HW215 size 64 8 light comp PRS comp OTA
+	  Texture HW221 size 8 32 light comp PRS comp OTA
 
-    ; Lights, suitable for lighting recesses and stuff.
-    Texture HW208 size 8 64 light comp CYB
+	  ; "Plaques", suitable for wall consoles and paintings and pillars and stuff.
+	  ; "vtiles" means that it's OK to pile one on top of another, as when
+	  ;    making the big central pillar in an arena.
+	  ; "half_plaque" means that the upper half of this texture can be used
+	  ;    by itself, as well as the whole thing.
+	  Texture SPCDOOR1 size 128 128 plaque comp PRS
+	  Texture STUCCO size 128 128 plaque vtiles comp OTA
+	  Texture STUCCO1 size 128 128 plaque vtiles comp OTA
+	  Texture STUCCO3 size 128 128 plaque comp OTA
 
-    ; "Plaques", suitable for wall consoles and paintings and pillars and stuff.
-    ; "vtiles" means that it's OK to pile one on top of another, as when
-    ;    making the big central pillar in an arena.
-    ; "half_plaque" means that the upper half of this texture can be used
-    ;    by itself, as well as the whole thing.
-    Texture COMPSTA1 size 16 128 plaque vtiles comp CYB
+	  ; Gratings
+	  Texture SPACEW3 size 128 128 grating comp PRS
+	  Texture HW203 size 128 128 grating comp PRS comp OTA
+	  Texture TEKGREN2 size 128 128 grating comp OTA
 
-    ; Gratings
-    Texture SLADRIP1 size 128 128 grating comp CYB
+	  ; Colors (suitable for marking key-locked things)
+	  Texture HW510 size 8 128 red comp PRS comp OTA
+	  Texture HW511 size 8 128 yellow comp PRS comp OTA
+	  Texture HW512 size 8 128 blue comp PRS comp OTA
 
-    ; Colors (suitable for marking key-locked things)
-    Texture HW510 size 8 128 red comp CYB
-    Texture HW511 size 8 128 yellow comp CYB
-    Texture HW512 size 8 128 blue comp CYB
+	  ; Step kickplates
+	  Texture HW216 size 64 8 step comp PRS comp OTA
 
-    ; Step kickplates
-    Texture HW216 size 64 8 step comp CYB
+	  ; "Doorjambs"
+	  Texture HW513 size 16 128 jamb comp PRS comp OTA
 
-    ; "Doorjambs"
-    Texture HW513 size 16 128 jamb comp CYB
+	  ; Support textures, used in various places
+	  Texture BIGBRIK3 size 128 128 support comp PRS comp OTA
 
-    ; Support textures, used in various places
-    Texture BIGBRIK3 size 128 128 support comp CYB
+	  ; Bunch of things for outside patios (no themes applied here)
+	  Texture PANEL2 size 128 128 outside
+	  Texture PANEL3 size 128 128 outside
 
-    ; Bunch of things for outside patios (no themes applied here)
-	  Texture BRICK10 size 128 128 outside
+	  ; Misc
+	  Texture BROWNGRN size 128 128 error
 
-    ; Misc
-    Texture TANROCK2 size 128 128 error
+	  ; Now the flats.  Keywords should all be pretty obvious...   *8)
 
-    ; Now the flats.  Keywords should all be pretty obvious...   *8)
+	  ; Teleport-gate floors
+	  Flat BLOOD1 gate comp PRS comp OTA
 
-    ; Teleport-gate floors
-    Flat BLOOD1 gate comp CYB
+	  ; Prison floors and ceilings
+	  Flat FLOOR0_1 floor comp PRS
+	  Flat CEIL3_2 ceiling comp PRS
+	  Flat CEIL4_3 ceiling comp PRS
+	  Flat SFLR6_1 ceiling light comp PRS
+	  Flat SFLR6_4 ceiling light comp PRS
+	  Flat TLITE6_5 floor comp PRS
+	  Flat DEM1_3 floor comp PRS
+	  Flat FLOOR6_1 ceiling comp PRS
 
-    ; Cyb floors and ceilings
-    Flat FLOOR0_3 floor comp CYB
-    Flat FLOOR0_3 ceiling comp CYB
-    Flat FLOOR0_3 ceiling light comp CYB
-    Flat FLOOR4_5 floor comp CYB
-    Flat FLOOR4_5 ceiling comp CYB
-    Flat FLOOR4_5 ceiling light comp CYB
-    Flat COMP01 floor comp CYB
-    Flat COMP01 ceiling comp CYB
-    Flat CEIL1_2 floor comp CYB
-    Flat CEIL1_2 ceiling comp CYB
-    Flat CEIL3_6 floor comp CYB
-    Flat CEIL3_6 ceiling comp CYB
-    Flat FLAT1 floor comp CYB
-    Flat FLAT1 ceiling comp CYB
-    Flat SLIME05 floor outside comp CYB
-    Flat MFLR8_4 ceiling outside comp CYB
+	  ; Digi-Ota floors and ceilings
+	  Flat FLOOR5_2 floor comp OTA
+	  Flat FLOOR0_5 floor comp OTA
+	  Flat FLAT5_2 floor comp OTA
+	  Flat MFLR8_2 ceiling comp OTA
+	  Flat MFLR8_3 ceiling comp OTA
+	  Flat FLAT5_3 ceiling comp OTA
 
-    ; and nukage
-    Flat NUKAGE1 nukage comp CYB
-    Flat LAVA1 nukage red comp CYB
+	  ; and nukage
+	  Flat SLIME01 nukage comp PRS comp OTA
+	  Flat SLIME09 nukage comp PRS comp OTA
+	  Flat LAVA1 nukage red comp PRS comp OTA
 
-    ; Floors for outside areas not yet mentioned
-    Flat SLIME05 outside
+	  ; Floors for outside areas not yet mentioned
+	  Flat CONS1_7 outside
+	  Flat FLAT23 outside
 
-    ; These are the defaults, but we'll list them anyway.
-    Flat FWATER1 water
-    Flat F_SKY1 sky
+	  ; These are the defaults, but we'll list them anyway.
+	  Flat FWATER1 water
+	  Flat F_SKY1 sky
 
-    ; Constructs: computers and crates and stuff that stand around in rooms
-    ; This is pretty complex!  Fool with it at your peril.
+	  ; Constructs: computers and crates and stuff that stand around in rooms
+	  ; This is pretty complex!  Fool with it at your peril.
 
-    ; Family 1 is crates of various sizes and kinds
-    Construct family 1 height 128 comp CYB
-      top FLOOR0_2
-      Primary BLAKWAL2 width 128
+	  ; Family 1 is crates of various sizes and kinds
+	  Construct family 1 height 128 comp PRS comp OTA
+	  top FLOOR0_2
+	  Primary BRICK10 width 128
 
-    ; Load the hardwired monster and object and so on data (required in
-    ; this version of SLIGE; don't remove this!)
-    Hardwired1
+	  ; Load the hardwired monster and object and so on data (required in
+	  ; this version of SLIGE; don't remove this!)
+	  Hardwired1
 
-    ; Say which lamps we like in which themes, and where barrels are allowed
-    ; Information like which Doom version each object is in, and which ones
-    ; cast light, and which ones explode, is still hardwired.
-    Thing 2028 comp CYB ; floor lamp
+	  ; Say which lamps we like in which themes, and where barrels are allowed
+	  ; Information like which Doom version each object is in, and which ones
+	  ; cast light, and which ones explode, is still hardwired.
+	  Thing 2028 comp PRS comp OTA ; floor lamp
 
     ; and that's it!
     ]]

--- a/source_files/slump/slump.cc
+++ b/source_files/slump/slump.cc
@@ -1077,7 +1077,7 @@ void secretize_config(config *c)
     }
 
     /* Sometimes some DooM II nazis */
-    if (rollpercent(80)&&!(c->gamemask&(DOOM0_BIT|DOOM1_BIT|HERETIC_BIT|CHEX_BIT))) {
+    if (rollpercent(80)&&!(c->gamemask&(DOOM0_BIT|DOOM1_BIT|HERETIC_BIT|CHEX_BIT|HACX_BIT))) {
       c->forbidden_monster_bits &= ~SPECIAL;
       something_special = SLUMP_TRUE;
       if (rollpercent(50)) {
@@ -8493,7 +8493,7 @@ boolean hardwired_nonswitch_nontheme_config(config *c)
     m = find_genus(c,ID_CELLPACK);
     m->bits |= AMMO;
     m->ammo_provides = (float)2000;  /* Hoo-hoo!  Same for BFG as plasgun? */
-  } else {
+  } else if (c->gamemask & HERETIC_BIT) {
     // Heretic decor
     m = find_genus(c,ID_POD);
     m->bits &= ~PICKABLE;
@@ -8530,6 +8530,42 @@ boolean hardwired_nonswitch_nontheme_config(config *c)
     m = find_genus(c,ID_MACESPHEREPILE);
     m->bits |= AMMO;
     m->ammo_provides = (float)500;
+  } else if (c->gamemask & HACX_BIT) {
+    // Hacx decor
+    m = find_genus(c,ID_BARREL);
+    m->bits &= ~PICKABLE;
+    m->bits |= EXPLODES;
+    m->width = 33;
+    m->gamemask = HACX_BIT;
+    m = find_genus(c,ID_CEILINGLAMP);
+    m->bits &= ~PICKABLE;
+    m->bits |= LIGHT;
+    m->width = 33;
+    m->height = 32;
+    m->gamemask = HACX_BIT;
+    m = find_genus(c,ID_TALLCEILINGLAMP);
+    m->bits &= ~PICKABLE;
+    m->bits |= LIGHT;
+    m->width = 33;
+    m->height = 64;
+    m->gamemask = HACX_BIT;
+    m = find_genus(c,ID_FLOORLAMP);
+    m->bits &= ~PICKABLE;
+    m->bits |= LIGHT;
+    m->width = 33;
+    m->height = 128;
+    m->gamemask = HACX_BIT;
+
+    // Hacx ammo (pretty much the same as Doom ammo)
+    m = find_genus(c,ID_ROCKBOX);
+    m->bits |= AMMO;
+    m->ammo_provides = (float)500;
+    m = find_genus(c,ID_BULBOX);
+    m->bits |= AMMO;
+    m->ammo_provides = (float)500;
+    m = find_genus(c,ID_CELLPACK);
+    m->bits |= AMMO;
+    m->ammo_provides = (float)2000;  /* Hoo-hoo!  Same for BFG as plasgun? */
   }
 
   /* violence and mayhem */
@@ -9004,6 +9040,213 @@ boolean hardwired_nonswitch_nontheme_config(config *c)
     m->bits |= SHOOTS;
     m->bits |= BOSS;
     m->bits |= BIG;
+  }
+
+/* Hacx monsters */
+  if (c->gamemask&(HACX_BIT)) {
+    m = find_monster(c,ID_THUG);
+    m->gamemask = HACX_BIT;
+    m->width = 44;
+    m->height = 72;
+    m->ammo_provides = (float)100;
+    m->ammo_to_kill[ITYTD] = (float)160;
+    m->ammo_to_kill[HMP] = (float)95;
+    m->ammo_to_kill[UV] = (float)80;
+    m->damage[ITYTD] = (float)15;
+    m->damage[HMP] = (float)3;
+    m->damage[UV] = (float)1;
+    m->altdamage[ITYTD] = (float)10;
+    m->altdamage[HMP] = (float)1;
+    m->altdamage[UV] = (float)1;
+    m->bits |= SHOOTS;
+    m->min_level = 1;
+    m = find_monster(c,ID_ANDROID);
+    m->gamemask = HACX_BIT;
+    m->width = 44;
+    m->height = 70;
+    m->ammo_provides = (float)280;
+    m->ammo_to_kill[ITYTD] = (float)200;
+    m->ammo_to_kill[HMP] = (float)120;
+    m->ammo_to_kill[UV] = (float)100;
+    m->damage[ITYTD] = (float)25;
+    m->damage[HMP] = (float)6;
+    m->damage[UV] = (float)2;
+    m->altdamage[ITYTD] = (float)20;
+    m->altdamage[HMP] = (float)2;
+    m->altdamage[UV] = (float)1;
+    m->bits |= SHOOTS;
+    m->min_level = 1;
+    m = find_monster(c,ID_BUZZER);
+    m->gamemask = HACX_BIT;
+    m->width = 52;
+    m->height = 68;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)440;
+    m->ammo_to_kill[HMP] = (float)265;
+    m->ammo_to_kill[UV] = (float)230;
+    m->damage[ITYTD] = (float)75;
+    m->damage[HMP] = (float)35;
+    m->damage[UV] = (float)15;
+    m->altdamage[ITYTD] = (float)60;
+    m->altdamage[HMP] = (float)25;
+    m->altdamage[UV] = (float)10;
+    m->bits |= FLIES;
+    m->min_level = 1;
+    m = find_monster(c,ID_STEALTHBUZZER);
+    m->gamemask = HACX_BIT;
+    m->width = 52;
+    m->height = 68;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)440;
+    m->ammo_to_kill[HMP] = (float)265;
+    m->ammo_to_kill[UV] = (float)230;
+    m->damage[ITYTD] = (float)75;
+    m->damage[HMP] = (float)35;
+    m->damage[UV] = (float)15;
+    m->altdamage[ITYTD] = (float)60;
+    m->altdamage[HMP] = (float)25;
+    m->altdamage[UV] = (float)10;
+    m->bits |= FLIES;
+    m->min_level = 1;
+    m = find_monster(c,ID_HACXPHAGE);
+    m->gamemask = HACX_BIT;
+    m->width = 52;
+    m->height = 96;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)375;
+    m->ammo_to_kill[HMP] = (float)225;
+    m->ammo_to_kill[UV] = (float)200;
+    m->damage[ITYTD] = (float)32;
+    m->damage[HMP] = (float)16;
+    m->damage[UV] = (float)8;
+    m->altdamage[ITYTD] = (float)20;
+    m->altdamage[HMP] = (float)10;
+    m->altdamage[UV] = (float)6;
+    m->bits |= SHOOTS;
+    m->min_level = 2;
+    m = find_monster(c,ID_ICE);
+    m->gamemask = HACX_BIT;
+    m->width = 66;
+    m->height = 55;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)560;
+    m->ammo_to_kill[HMP] = (float)340;
+    m->ammo_to_kill[UV] = (float)300;
+    m->damage[ITYTD] = (float)22;
+    m->damage[HMP] = (float)8;
+    m->damage[UV] = (float)5;
+    m->altdamage[ITYTD] = (float)18;
+    m->altdamage[HMP] = (float)5;
+    m->altdamage[UV] = (float)2;
+    m->bits |= FLIES;
+    m->min_level = 5;
+    m = find_monster(c,ID_DMAN);
+    m->gamemask = HACX_BIT;
+    m->width = 98;
+    m->height = 77;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)625;
+    m->ammo_to_kill[HMP] = (float)375;
+    m->ammo_to_kill[UV] = (float)325;
+    m->damage[ITYTD] = (float)22;
+    m->damage[HMP] = (float)8;
+    m->damage[UV] = (float)5;
+    m->altdamage[ITYTD] = (float)18;
+    m->altdamage[HMP] = (float)5;
+    m->altdamage[UV] = (float)2;
+    m->bits |= FLIES | BIG;
+    m->min_level = 5;
+    m = find_monster(c,ID_MAJONG7);
+    m->gamemask = HACX_BIT;
+    m->width = 64;
+    m->height = 56;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)1500;
+    m->ammo_to_kill[HMP] = (float)600;
+    m->ammo_to_kill[UV] = (float)520;
+    m->min_level = 2;
+    m->bits |= SHOOTS;
+    m = find_monster(c,ID_MONSTRUCT);
+    m->gamemask = HACX_BIT;
+    m->width = 72;
+    m->height = 87;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)1500;
+    m->ammo_to_kill[HMP] = (float)600;
+    m->ammo_to_kill[UV] = (float)520;
+    m->ammo_provides = (float)100;
+    m->damage[ITYTD] = (float)100;
+    m->damage[HMP] = (float)50;
+    m->damage[UV] = (float)25;
+    m->altdamage[ITYTD] = (float)80;
+    m->altdamage[HMP] = (float)40;
+    m->altdamage[UV] = (float)15;
+    m->min_level = 2;
+    m->bits |= SHOOTS | BIG;
+    m = find_monster(c,ID_TERMINATRIX);
+    m->gamemask = HACX_BIT;
+    m->width = 50;
+    m->height = 96;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)2000;
+    m->ammo_to_kill[HMP] = (float)1200;
+    m->ammo_to_kill[UV] = (float)1040;
+    m->damage[ITYTD] = (float)90;
+    m->damage[HMP] = (float)45;
+    m->damage[UV] = (float)20;
+    m->altdamage[ITYTD] = (float)75;
+    m->altdamage[HMP] = (float)35;
+    m->altdamage[UV] = (float)13;
+    m->min_level = 9;
+    m->bits |= SHOOTS | BOSS;
+    m = find_monster(c,ID_THORNTHING);
+    m->gamemask = HACX_BIT;
+    m->width = 130;
+    m->height = 96;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)1500;
+    m->ammo_to_kill[HMP] = (float)900;
+    m->ammo_to_kill[UV] = (float)780;
+    m->damage[ITYTD] = (float)125;
+    m->damage[HMP] = (float)70;
+    m->damage[UV] = (float)40;
+    m->altdamage[ITYTD] = (float)100;
+    m->altdamage[HMP] = (float)40;
+    m->altdamage[UV] = (float)25;
+    m->min_level = 9;
+    m->bits |= SHOOTS | BOSS | BIG;
+    m = find_monster(c,ID_MECHAMANIAC);
+    m->gamemask = HACX_BIT;
+    m->width = 50;
+    m->height = 96;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)2000;
+    m->ammo_to_kill[HMP] = (float)1200;
+    m->ammo_to_kill[UV] = (float)1040;
+    m->damage[ITYTD] = (float)150;
+    m->damage[HMP] = (float)90;
+    m->damage[UV] = (float)50;
+    m->altdamage[ITYTD] = (float)120;
+    m->altdamage[HMP] = (float)80;
+    m->altdamage[UV] = (float)40;
+    m->min_level = 9;
+    m->bits |= SHOOTS | BOSS;
+    m = find_monster(c,ID_ROAMINGMINE);
+    m->gamemask = HACX_BIT;
+    m->width = 18;
+    m->height = 32;
+    m->ammo_provides = (float)0;
+    m->ammo_to_kill[ITYTD] = (float)125;
+    m->ammo_to_kill[HMP] = (float)75;
+    m->ammo_to_kill[UV] = (float)65;
+    m->damage[ITYTD] = (float)100;
+    m->damage[HMP] = (float)50;
+    m->damage[UV] = (float)15;
+    m->altdamage[ITYTD] = (float)80;
+    m->altdamage[HMP] = (float)40;
+    m->altdamage[UV] = (float)10;
+    m->min_level = 16;
+    m->bits |= FLIES;
   }
 
   return SLUMP_TRUE;
@@ -12411,7 +12654,9 @@ void empty_level(level *l, config *c)
    l->first_room = NULL;
    if ((c->gamemask & HERETIC_BIT) || (c->gamemask & CHEX_BIT)) {
     l->skullkeys = SLUMP_FALSE;
-   } else {
+   } else if (c->gamemask & HACX_BIT) {
+    l->skullkeys = rollpercent(100);
+  } else {
     l->skullkeys = rollpercent(50);
    }
    l->use_gates = rollpercent(TELEPORTS_PERCENT);

--- a/source_files/slump/slump.h
+++ b/source_files/slump/slump.h
@@ -256,6 +256,20 @@ typedef struct s_genus {
 #define ID_MAULOTAUR (0x09)
 #define ID_IRONLICH (0x06)
 #define ID_DSPARIL (0x07)
+/* The Hacx Monsters*/
+#define ID_THUG (0x0bbc)
+#define ID_ANDROID (0x0009)
+#define ID_BUZZER (0x0bba)
+#define ID_STEALTHBUZZER (0x003a)
+#define ID_HACXPHAGE (0x0043)
+#define ID_ICE (0x0bb9)
+#define ID_DMAN (0xbbe)
+#define ID_MAJONG7 (0x047)
+#define ID_MONSTRUCT (0x041)
+#define ID_TERMINATRIX (0x0bbb)
+#define ID_THORNTHING (0x044)
+#define ID_MECHAMANIAC (0x045)
+#define ID_ROAMINGMINE (0x054)
   short width;
   short height;
   int min_level; /* Minimum level to put monster in */
@@ -376,6 +390,10 @@ typedef struct s_genus {
 #define ID_SMSTALAGMITE (0x25)
 #define ID_LGSTALAGMITE (0x26)
 
+// Hacx decor
+#define ID_CEILINGLAMP (0x02c)
+#define ID_TALLCEILINGLAMP (0x02e)
+#define ID_FLOORLAMP (0x039)
 
 /* The style is the dynamic architectural knowledge and stuff. */
 /* It changes throughout the run.                              */


### PR DESCRIPTION
This pull request improves the enemy progression in SLUMP levels for Hacx and replaces the Cyberspace theme with two new ones that are more consistent visually. There's a couple things I'll have to investigate later like the enemy amount being seemingly excessive or most of the weapons not spawning in the maps, but most of the hard work has been done here.